### PR TITLE
chore(deps): bump @stacks/blockchain-api-client from 9.0.0-next.36 to 9.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@sentry/nextjs": "10.44.0",
     "@sentry/profiling-node": "10.44.0",
     "@stacks/auth": "7.1.0",
-    "@stacks/blockchain-api-client": "9.0.0-next.36",
+    "@stacks/blockchain-api-client": "9.0.2",
     "@stacks/common": "7.0.2",
     "@stacks/connect": "8.1.9",
     "@stacks/connect-ui": "8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: 7.1.0
         version: 7.1.0
       '@stacks/blockchain-api-client':
-        specifier: 9.0.0-next.36
-        version: 9.0.0-next.36
+        specifier: 9.0.2
+        version: 9.0.2
       '@stacks/common':
         specifier: 7.0.2
         version: 7.0.2
@@ -2786,8 +2786,8 @@ packages:
   '@stacks/auth@7.1.0':
     resolution: {integrity: sha512-I2Wlk2ucM0roXSF7aDUThyLQan3PIkqC7QQ1ZL1ulorha7IraqubasJX8j/q/ZE58z9gQnPOf0ayf0r0ocNOuQ==}
 
-  '@stacks/blockchain-api-client@9.0.0-next.36':
-    resolution: {integrity: sha512-uNE36sHSZJXpobWQjGhs7l/SepqFVAj0zI9SNw+V2VWPGVr+x5c4+kOpQyekym/2JRpsQ0V6m7DJvWzMpSF2Yw==}
+  '@stacks/blockchain-api-client@9.0.2':
+    resolution: {integrity: sha512-5e52LJNsO0eBFK+mx0u6d3vCdDzMDNb7n2o8QFIhnIlh9/2mJn/rpN1AFGzZZVeybVaOdvK9BzeTmkdlLltshg==}
 
   '@stacks/common@6.16.0':
     resolution: {integrity: sha512-PnzvhrdGRMVZvxTulitlYafSK4l02gPCBBoI9QEoTqgSnv62oaOXhYAUUkTMFKxdHW1seVEwZsrahuXiZPIAwg==}
@@ -11532,7 +11532,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@stacks/blockchain-api-client@9.0.0-next.36':
+  '@stacks/blockchain-api-client@9.0.2':
     dependencies:
       '@types/node': 20.14.14
       eventemitter3: 4.0.7

--- a/src/common/components/table/table-examples/TxTableCellRenderers.tsx
+++ b/src/common/components/table/table-examples/TxTableCellRenderers.tsx
@@ -86,58 +86,64 @@ export const IconCellRenderer = (value: ReactNode) => {
   );
 };
 
-function getTxStatusIcon(status: TransactionStatus | MempoolTransactionStatus) {
+type TxStatusTagStatus =
+  | TransactionStatus
+  | MempoolTransactionStatus
+  | TransactionSummary['status'];
+
+function getTxStatusIcon(status: TxStatusTagStatus) {
   switch (status) {
     case 'pending':
       return <Clock />;
     case 'abort_by_post_condition':
-      return <XCircle />;
     case 'abort_by_response':
+    case 'problematic_skipped':
       return <XCircle />;
     default:
       return <Question />;
   }
 }
 
-function getTxStatusIconColor(status: TransactionStatus | MempoolTransactionStatus) {
+function getTxStatusIconColor(status: TxStatusTagStatus) {
   switch (status) {
     case 'pending':
       return 'feedback.bronze-600';
     case 'abort_by_post_condition':
-      return 'feedback.red-600';
     case 'abort_by_response':
+    case 'problematic_skipped':
       return 'feedback.red-600';
     default:
       return 'iconSecondary';
   }
 }
 
-function getTxStatusBgColor(status: TransactionStatus | MempoolTransactionStatus) {
+function getTxStatusBgColor(status: TxStatusTagStatus) {
   switch (status) {
     case 'pending':
       return 'transactionStatus.pending';
     case 'abort_by_post_condition':
-      return 'transactionStatus.failed';
     case 'abort_by_response':
+    case 'problematic_skipped':
       return 'transactionStatus.failed';
     default:
       return 'surfaceSecondary';
   }
 }
 
-function getTxStatusLabel(status: TransactionStatus | MempoolTransactionStatus) {
+function getTxStatusLabel(status: TxStatusTagStatus) {
   switch (status) {
     case 'pending':
       return 'Pending';
     case 'abort_by_post_condition':
     case 'abort_by_response':
+    case 'problematic_skipped':
       return 'Failed';
     default:
       return status;
   }
 }
 
-export const StatusTag = ({ status }: { status: TransactionStatus | MempoolTransactionStatus }) => {
+export const StatusTag = ({ status }: { status: TxStatusTagStatus }) => {
   return (
     <Flex
       alignItems="center"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
bump @stacks/blockchain-api-client from 9.0.0-next.36 to 9.0.2

the pinned prerelease was behind: 95 typed paths vs 115 on 9.0.2, missing the sbtc faucet, v3 staking and pox-5 endpoints. needed for the sbtc faucet work in #2807.

the bump surfaced one real bug: the v3 tx feed can return a `problematic_skipped` status that `StatusTag` didn't model, so it fell through every `default:` branch and rendered a grey tag with the raw string `problematic_skipped` as its aria-label. it now matches `getV3TxStatus`, which already classifies it as failed.

## Issue ticket number and link

# Checklist:
- [x] I have performed a self-review of my code.
- [ ] I have tested the change on desktop and mobile.
- [x] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
