### PR TITLE
feat: support pox-5 post-conditions and originator mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@stacks/connect-ui": "8.0.0",
     "@stacks/network": "7.0.2",
     "@stacks/token-metadata-api-client": "2.2.1",
-    "@stacks/transactions": "7.1.0",
+    "@stacks/transactions": "7.6.0",
     "@storybook/addon-themes": "8.6.9",
     "@tanstack/react-query": "5.69.0",
     "@tanstack/react-table": "8.21.3",
@@ -168,6 +168,7 @@
   },
   "resolutions": {
     "eslint": "8.54.0",
+    "@stacks/transactions": "7.6.0",
     "bn.js": "5.1.3",
     "buffer": "6.0.3",
     "schema-inspector": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   eslint: 8.54.0
+  '@stacks/transactions': 7.6.0
   bn.js: 5.1.3
   buffer: 6.0.3
   schema-inspector: 2.0.0
@@ -87,8 +88,8 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
       '@stacks/transactions':
-        specifier: 7.1.0
-        version: 7.1.0
+        specifier: 7.6.0
+        version: 7.6.0
       '@storybook/addon-themes':
         specifier: 8.6.9
         version: 8.6.9(storybook@8.6.15(prettier@3.5.3))
@@ -2798,6 +2799,9 @@ packages:
   '@stacks/common@7.3.1':
     resolution: {integrity: sha512-29ANTFcSSlXnGQlgDVWg7OQ74lgQhu3x8JkeN19Q+UE/1lbQrzcctgPHG74XHjWNp8NPBqskUYA8/HLgIKuKNQ==}
 
+  '@stacks/common@7.6.0':
+    resolution: {integrity: sha512-VUW8WDmZP4wXUNWVvpFerV+7LQ0PqIn8YOs8AjSUMA7ZOXIRLxJHoKxjfiHzJqazy7KlyryPW4kSNBCr7tLqhQ==}
+
   '@stacks/connect-ui@8.0.0':
     resolution: {integrity: sha512-m8yqg28EWQCATkVxILotzbqvcnk0n+qhyncTTNEYXVe4VnfV0eRXvxX88nbA/fot1k+MuQlMu3WhrBFLHJ/xzA==}
 
@@ -2827,6 +2831,9 @@ packages:
   '@stacks/network@7.3.1':
     resolution: {integrity: sha512-dQjhcwkz8lihSYSCUMf7OYeEh/Eh0++NebDtXbIB3pHWTvNCYEH7sxhYTB1iyunurv31/QEi0RuWdlfXK/BjeA==}
 
+  '@stacks/network@7.6.0':
+    resolution: {integrity: sha512-Blm85nsEbvJoFIFaDp0QE9WMC0Hf+o3Yb0oIDwWu3PPgpVSdndb/bJQUeT6eJTs0ibS26A2E/5d5L0fb4Ff/lA==}
+
   '@stacks/prettier-config@0.0.10':
     resolution: {integrity: sha512-MrYWGEgO/mYR8TOZIKknQEHbFQZ5VyAD/s8eF2Yxr6Lgalt2alVEh+6ODehVP2uepkyXPmJzLbaQYs8/L4E78Q==}
 
@@ -2852,14 +2859,8 @@ packages:
   '@stacks/transactions@6.17.0':
     resolution: {integrity: sha512-FUah2BRgV66ApLcEXGNGhwyFTRXqX5Zco3LpiM3essw8PF0NQlHwwdPgtDko5RfrJl3LhGXXe/30nwsfNnB3+g==}
 
-  '@stacks/transactions@7.0.5':
-    resolution: {integrity: sha512-mHsv7lUbZ5w4MKJ3NAirtdClIXLNKMqWIqT2rLjbIHzlYBqvZaELJSYD+km6E7Cm9G3yUYszorhruQmSTgilbg==}
-
-  '@stacks/transactions@7.1.0':
-    resolution: {integrity: sha512-/4n5h+ka5N3mq16f1Zo0O0g2gyOYhaXFdGN8ifLz38NJmkjnCDXqi/ogB6NFNpSKGonyqyF5Vz1UPaQHwO8+IA==}
-
-  '@stacks/transactions@7.3.1':
-    resolution: {integrity: sha512-ufnC1BPrOKz5b5gxxdseP3vBrFq1+qx1L6t+J/QnjXULyWdkhtS+LBEqRw2bL5qNteMvU2GhqPgFtYQPzolGbw==}
+  '@stacks/transactions@7.6.0':
+    resolution: {integrity: sha512-s7F7eJtQVnZoB79j8pY9SLKhlvvdYZZD1NSDRWrFjzSJTDmxptL8c50S563WFja6KOhFOgg1jd+p0XWTxFAVyA==}
 
   '@stencil/core@2.22.3':
     resolution: {integrity: sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==}
@@ -4309,7 +4310,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@stacks/network': ^7.0.2
-      '@stacks/transactions': ^7.0.2
+      '@stacks/transactions': 7.6.0
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -4750,7 +4751,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@stacks/common': ^7.0.2
-      '@stacks/transactions': ^7.0.2
+      '@stacks/transactions': 7.6.0
 
   clean-css@5.3.3:
     resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
@@ -10600,8 +10601,8 @@ snapshots:
       '@stacks/network': 7.0.2
       '@stacks/stacking': 7.0.5
       '@stacks/stacks-blockchain-api-types': 7.14.1
-      '@stacks/transactions': 7.0.5
-      alex-sdk: 3.1.0(@stacks/common@7.0.2)(@stacks/network@7.0.2)(@stacks/transactions@7.0.5)
+      '@stacks/transactions': 7.6.0
+      alex-sdk: 3.1.0(@stacks/common@7.0.2)(@stacks/network@7.0.2)(@stacks/transactions@7.6.0)
       axios: 1.8.4
       bignumber.js: 9.1.2
       lodash.get: 4.4.2
@@ -10620,7 +10621,7 @@ snapshots:
       '@leather.io/utils': 0.31.2
       '@scure/btc-signer': 1.6.0
       '@stacks/network': 7.0.2
-      '@stacks/transactions': 7.0.5
+      '@stacks/transactions': 7.6.0
       zod: 3.24.2
     transitivePeerDependencies:
       - encoding
@@ -10637,7 +10638,7 @@ snapshots:
       '@stacks/encryption': 7.0.2
       '@stacks/network': 7.0.2
       '@stacks/stacks-blockchain-api-types': 7.8.2
-      '@stacks/transactions': 7.0.5
+      '@stacks/transactions': 7.6.0
       bignumber.js: 9.1.2
       c32check: 2.0.0
     transitivePeerDependencies:
@@ -10655,7 +10656,7 @@ snapshots:
       '@stacks/encryption': 7.0.2
       '@stacks/network': 7.0.2
       '@stacks/stacks-blockchain-api-types': 7.14.1
-      '@stacks/transactions': 7.0.5
+      '@stacks/transactions': 7.6.0
       bignumber.js: 9.1.2
       c32check: 2.0.0
     transitivePeerDependencies:
@@ -11553,6 +11554,8 @@ snapshots:
 
   '@stacks/common@7.3.1': {}
 
+  '@stacks/common@7.6.0': {}
+
   '@stacks/connect-ui@8.0.0':
     dependencies:
       '@stencil/core': 2.22.3
@@ -11565,7 +11568,7 @@ snapshots:
       '@stacks/network': 7.0.2
       '@stacks/network-v6': '@stacks/network@6.17.0'
       '@stacks/profile': 7.3.1
-      '@stacks/transactions': 7.1.0
+      '@stacks/transactions': 7.6.0
       '@stacks/transactions-v6': '@stacks/transactions@6.17.0'
     transitivePeerDependencies:
       - encoding
@@ -11629,6 +11632,13 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@stacks/network@7.6.0':
+    dependencies:
+      '@stacks/common': 7.6.0
+      cross-fetch: 3.2.0
+    transitivePeerDependencies:
+      - encoding
+
   '@stacks/prettier-config@0.0.10':
     dependencies:
       prettier: 2.5.1
@@ -11637,7 +11647,7 @@ snapshots:
     dependencies:
       '@stacks/common': 7.3.1
       '@stacks/network': 7.3.1
-      '@stacks/transactions': 7.3.1
+      '@stacks/transactions': 7.6.0
       jsontokens: 4.0.1
       schema-inspector: 2.0.0
       zone-file: 2.0.0-beta.3
@@ -11652,7 +11662,7 @@ snapshots:
       '@stacks/encryption': 7.3.1
       '@stacks/network': 7.0.2
       '@stacks/stacks-blockchain-api-types': 0.61.0
-      '@stacks/transactions': 7.1.0
+      '@stacks/transactions': 7.6.0
       bs58: 5.0.0
     transitivePeerDependencies:
       - encoding
@@ -11678,34 +11688,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@stacks/transactions@7.0.5':
+  '@stacks/transactions@7.6.0':
     dependencies:
       '@noble/hashes': 1.1.5
       '@noble/secp256k1': 1.7.1
-      '@stacks/common': 7.0.2
-      '@stacks/network': 7.0.2
-      c32check: 2.0.0
-      lodash.clonedeep: 4.5.0
-    transitivePeerDependencies:
-      - encoding
-
-  '@stacks/transactions@7.1.0':
-    dependencies:
-      '@noble/hashes': 1.1.5
-      '@noble/secp256k1': 1.7.1
-      '@stacks/common': 7.0.2
-      '@stacks/network': 7.0.2
-      c32check: 2.0.0
-      lodash.clonedeep: 4.5.0
-    transitivePeerDependencies:
-      - encoding
-
-  '@stacks/transactions@7.3.1':
-    dependencies:
-      '@noble/hashes': 1.1.5
-      '@noble/secp256k1': 1.7.1
-      '@stacks/common': 7.3.1
-      '@stacks/network': 7.3.1
+      '@stacks/common': 7.6.0
+      '@stacks/network': 7.6.0
       c32check: 2.0.0
       lodash.clonedeep: 4.5.0
     transitivePeerDependencies:
@@ -14042,11 +14030,11 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alex-sdk@3.1.0(@stacks/common@7.0.2)(@stacks/network@7.0.2)(@stacks/transactions@7.0.5):
+  alex-sdk@3.1.0(@stacks/common@7.0.2)(@stacks/network@7.0.2)(@stacks/transactions@7.6.0):
     dependencies:
       '@stacks/network': 7.0.2
-      '@stacks/transactions': 7.0.5
-      clarity-codegen: 1.0.0-beta.1(@stacks/common@7.0.2)(@stacks/transactions@7.0.5)
+      '@stacks/transactions': 7.6.0
+      clarity-codegen: 1.0.0-beta.1(@stacks/common@7.0.2)(@stacks/transactions@7.6.0)
     transitivePeerDependencies:
       - '@stacks/common'
       - debug
@@ -14377,7 +14365,7 @@ snapshots:
     dependencies:
       '@stacks/common': 6.16.0
       '@stacks/network': 6.17.0
-      '@stacks/transactions': 7.1.0
+      '@stacks/transactions': 7.6.0
       axios: 1.13.2
     transitivePeerDependencies:
       - debug
@@ -14586,11 +14574,11 @@ snapshots:
 
   cjs-module-lexer@2.2.0: {}
 
-  clarity-codegen@1.0.0-beta.1(@stacks/common@7.0.2)(@stacks/transactions@7.0.5):
+  clarity-codegen@1.0.0-beta.1(@stacks/common@7.0.2)(@stacks/transactions@7.6.0):
     dependencies:
       '@stacks/common': 7.0.2
       '@stacks/stacks-blockchain-api-types': 7.14.1
-      '@stacks/transactions': 7.0.5
+      '@stacks/transactions': 7.6.0
       axios: 1.8.4
       lodash: 4.17.21
       yargs: 17.7.2

--- a/src/app/sandbox/components/ContractCall/FunctionView.tsx
+++ b/src/app/sandbox/components/ContractCall/FunctionView.tsx
@@ -198,8 +198,6 @@ export const FunctionView: FC<FunctionViewProps> = ({ fn, contractId, cancelButt
           postConditionAssetName,
         } = values;
 
-        // Resolved once: two consumers below read this, and an undefined mode
-        // must not let one attach post-conditions while the other sends 'allow'
         const submittedPostConditionMode = postConditionMode ?? PostConditionMode.Deny;
 
         if (fn.access === 'public') {

--- a/src/app/sandbox/components/ContractCall/FunctionView.tsx
+++ b/src/app/sandbox/components/ContractCall/FunctionView.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Box, Flex, Icon, Stack } from '@chakra-ui/react';
-import { Info } from '@phosphor-icons/react';
+import { Box, Flex, Stack } from '@chakra-ui/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Form, Formik, FormikErrors } from 'formik';
 import { ChangeEvent, FC, ReactNode, useMemo, useState } from 'react';
@@ -18,13 +17,20 @@ import {
 } from '@stacks/transactions';
 
 import { Section } from '../../../../common/components/Section';
+import { Select } from '../../../../common/components/Select';
 import { useGlobalContext } from '../../../../common/context/useGlobalContext';
+import { logError } from '../../../../common/utils/error-utils';
 import { getConnectNetworkString } from '../../../../common/utils/network-utils';
+import {
+  postConditionModeDescriptions,
+  postConditionModeFromName,
+  postConditionModeNames,
+  postConditionModeOptions,
+} from '../../../../common/utils/post-condition-mode-utils';
 import { showFn } from '../../../../common/utils/sandbox';
-import { Switch } from '../../../../components/ui/switch';
+import { Alert } from '../../../../components/ui/alert';
 import { Button } from '../../../../ui/Button';
 import { Text } from '../../../../ui/Text';
-import { Tooltip } from '../../../../ui/Tooltip';
 import { ListValueType, NonTupleValueType, TupleValueType, ValueType } from '../../types/values';
 import { encodeOptional, encodeOptionalTuple, encodeTuple, getTuple } from '../../utils';
 import { callContract } from '../../utils/walletTransactions';
@@ -192,35 +198,47 @@ export const FunctionView: FC<FunctionViewProps> = ({ fn, contractId, cancelButt
           postConditionAssetName,
         } = values;
 
+        // Resolved once: two consumers below read this, and an undefined mode
+        // must not let one attach post-conditions while the other sends 'allow'
+        const submittedPostConditionMode = postConditionMode ?? PostConditionMode.Deny;
+
         if (fn.access === 'public') {
-          await callContract({
-            contract: contractId,
-            functionName: fn.name,
-            functionArgs: Object.values(final),
-            network: getConnectNetworkString(network),
-            postConditions:
-              postConditionMode === PostConditionMode.Allow
-                ? undefined
-                : postConditionType == null
-                  ? []
-                  : getPostCondition({
-                      postConditionType,
-                      postConditionAddress,
-                      postConditionConditionCode,
-                      postConditionAmount,
-                      postConditionAssetAddress,
-                      postConditionAssetContractName,
-                      postConditionAssetName,
-                    }),
-            postConditionMode: postConditionMode === PostConditionMode.Allow ? 'allow' : 'deny',
-          });
-          void queryClient.invalidateQueries({ queryKey: ['addressMempoolTxsInfinite'] });
+          try {
+            await callContract({
+              contract: contractId,
+              functionName: fn.name,
+              functionArgs: Object.values(final),
+              network: getConnectNetworkString(network),
+              postConditions:
+                submittedPostConditionMode === PostConditionMode.Allow
+                  ? undefined
+                  : postConditionType == null
+                    ? []
+                    : getPostCondition({
+                        postConditionType,
+                        postConditionAddress,
+                        postConditionConditionCode,
+                        postConditionAmount,
+                        postConditionAssetAddress,
+                        postConditionAssetContractName,
+                        postConditionAssetName,
+                      }),
+              postConditionMode: postConditionModeNames[submittedPostConditionMode],
+            });
+            void queryClient.invalidateQueries({ queryKey: ['addressMempoolTxsInfinite'] });
+          } catch (error) {
+            logError(error as Error, 'Error submitting sandbox contract call', {
+              contractId,
+              functionName: fn.name,
+            });
+          }
         } else {
           setReadonlyValue(Object.values(final));
         }
       }}
     >
       {({ handleSubmit, handleChange, values, errors, setFieldValue }) => {
+        const postConditionMode = values.postConditionMode ?? PostConditionMode.Allow;
         return (
           <Section
             overflowY="visible"
@@ -239,33 +257,28 @@ export const FunctionView: FC<FunctionViewProps> = ({ fn, contractId, cancelButt
               <Box p={4}>
                 <Form onSubmit={handleSubmit}>
                   <Stack gap={4}>
-                    <Flex justifyContent="flex-end" alignItems="center" gap={2}>
-                      <Text fontSize="sm">
-                        {values.postConditionMode === PostConditionMode.Deny
-                          ? 'Deny Mode'
-                          : 'Allow Mode'}
-                      </Text>
-                      <Switch
-                        variant="redesignPrimary"
-                        size="small"
-                        id="post-condition-mode"
-                        disabled={isReadOnly}
-                        onChange={() => {
-                          setFieldValue(
-                            'postConditionMode',
-                            values.postConditionMode === PostConditionMode.Deny
-                              ? PostConditionMode.Allow
-                              : PostConditionMode.Deny
-                          );
-                        }}
-                        checked={values.postConditionMode === PostConditionMode.Allow}
-                      />
-                      <Tooltip content="Allow mode is less secure than Deny mode. Allow mode permits asset transfers that are not covered by post conditions. In Deny mode no other asset transfers are permitted besides those named in the post conditions">
-                        <Icon h={5} w={5}>
-                          <Info />
-                        </Icon>
-                      </Tooltip>
-                    </Flex>
+                    {!isReadOnly && (
+                      <Stack gap={3}>
+                        <Flex justifyContent="flex-end" alignItems="center" gap={2} flexWrap="wrap">
+                          <Text fontSize="sm">Post-conditions:</Text>
+                          <Select
+                            defaultValue={[postConditionModeNames[postConditionMode]]}
+                            items={postConditionModeOptions}
+                            label="Post-condition mode"
+                            onValueChange={details => {
+                              const mode = postConditionModeFromName(details.value[0]);
+                              if (mode == null) return;
+                              setFieldValue('postConditionMode', mode);
+                            }}
+                            size="sm"
+                          />
+                        </Flex>
+                        <Alert
+                          status="neutral"
+                          description={postConditionModeDescriptions[postConditionMode]}
+                        />
+                      </Stack>
+                    )}
                     {fn.args.length && (
                       <>
                         {fn.args.map(({ name, type }) => (

--- a/src/app/sandbox/components/ContractCall/PostConditionForm.tsx
+++ b/src/app/sandbox/components/ContractCall/PostConditionForm.tsx
@@ -144,8 +144,6 @@ export const postConditionParameterMap: Record<PostConditionType, PostConditionP
     'postConditionAssetContractName',
     'postConditionAssetName',
   ],
-  // pox-5 staking and PoX post-conditions constrain the principal itself rather
-  // than an asset, so they take no asset parameters
   [PostConditionType.Staking]: [
     'postConditionAddress',
     'postConditionConditionCode',
@@ -282,8 +280,6 @@ export function getPostCondition(
     throw new Error(`There is no post condition type that matches ${postConditionType}`);
   }
 
-  // Nothing matched: return an empty list rather than [undefined], which
-  // callContract would otherwise try to serialize
   return postCondition ? [postCondition as PostCondition] : [];
 }
 

--- a/src/app/sandbox/components/ContractCall/PostConditionForm.tsx
+++ b/src/app/sandbox/components/ContractCall/PostConditionForm.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Icon, Stack } from '@chakra-ui/react';
 import { CaretDown } from '@phosphor-icons/react';
 import { Field, FormikErrors } from 'formik';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import {
   Cl,
@@ -15,6 +15,10 @@ import {
   PostCondition,
   PostConditionMode,
   PostConditionType,
+  PoxComparator,
+  PoxConditionCode,
+  PoxPostCondition,
+  StakingPostCondition,
   StxPostCondition,
   isClarityAbiOptional,
   isClarityAbiPrimitive,
@@ -29,7 +33,10 @@ import { Caption } from '../../../../ui/typography';
 import { NonTupleValueType } from '../../types/values';
 import { FormikSetFieldValueFunction, FunctionFormikState } from './FunctionView';
 
-type PostConditionConditionCode = FungibleConditionCode | NonFungibleConditionCode;
+type PostConditionConditionCode =
+  | FungibleConditionCode
+  | NonFungibleConditionCode
+  | PoxConditionCode;
 
 function isFungibleConditionCode(code: PostConditionConditionCode): code is FungibleConditionCode {
   return Object.values(FungibleConditionCode).includes(code as FungibleConditionCode);
@@ -58,6 +65,36 @@ function fungibleConditionCodeToComparator(code: FungibleConditionCode): Fungibl
   }
 }
 
+function isConditionCodeValidForType(
+  postConditionType: PostConditionType,
+  code: PostConditionConditionCode
+): boolean {
+  if (postConditionType === PostConditionType.NonFungible) {
+    return isNonFungibleConditionCode(code);
+  }
+  if (postConditionType === PostConditionType.PoX) {
+    return isPoxConditionCode(code);
+  }
+  return isFungibleConditionCode(code);
+}
+
+function isPoxConditionCode(code: PostConditionConditionCode): code is PoxConditionCode {
+  return Object.values(PoxConditionCode).includes(code as PoxConditionCode);
+}
+
+function poxConditionCodeToComparator(code: PoxConditionCode): PoxComparator {
+  switch (code) {
+    case PoxConditionCode.WillNotPerform:
+      return 'will-not-perform';
+    case PoxConditionCode.MayPerform:
+      return 'may-perform';
+    case PoxConditionCode.WillPerform:
+      return 'will-perform';
+    default:
+      return 'will-perform';
+  }
+}
+
 function nonFungibleConditionCodeToComparator(
   code: NonFungibleConditionCode
 ): NonFungibleComparator {
@@ -66,6 +103,8 @@ function nonFungibleConditionCodeToComparator(
       return 'sent';
     case NonFungibleConditionCode.DoesNotSend:
       return 'not-sent';
+    case NonFungibleConditionCode.MaybeSent:
+      return 'maybe-sent';
     default:
       return 'sent';
   }
@@ -105,6 +144,14 @@ export const postConditionParameterMap: Record<PostConditionType, PostConditionP
     'postConditionAssetContractName',
     'postConditionAssetName',
   ],
+  // pox-5 staking and PoX post-conditions constrain the principal itself rather
+  // than an asset, so they take no asset parameters
+  [PostConditionType.Staking]: [
+    'postConditionAddress',
+    'postConditionConditionCode',
+    'postConditionAmount',
+  ],
+  [PostConditionType.PoX]: ['postConditionAddress', 'postConditionConditionCode'],
 };
 
 export function isPostConditionParameter(key: string): key is keyof PostConditionParameters {
@@ -134,6 +181,8 @@ export const PostConditionOptions = [
   { label: 'STX Post Condition', value: PostConditionType.STX },
   { label: 'Fungible Post Condition', value: PostConditionType.Fungible },
   { label: 'Non-Fungible Post Condition', value: PostConditionType.NonFungible },
+  { label: 'Staking Post Condition', value: PostConditionType.Staking },
+  { label: 'PoX Post Condition', value: PostConditionType.PoX },
 ];
 
 export function getPostCondition(
@@ -199,14 +248,43 @@ export function getPostCondition(
       assetId: Cl.stringUtf8(postConditionAssetName),
     } as NonFungiblePostCondition;
   } else if (
+    postConditionType === PostConditionType.Staking &&
+    postConditionAddress &&
+    postConditionConditionCode &&
+    postConditionAmount != null &&
+    isUint128(postConditionAmount) &&
+    isFungibleConditionCode(postConditionConditionCode)
+  ) {
+    postCondition = {
+      type: 'staking-postcondition',
+      address: postConditionAddress,
+      condition: fungibleConditionCodeToComparator(postConditionConditionCode),
+      amount: postConditionAmount.toString(),
+    } as StakingPostCondition;
+  } else if (
+    postConditionType === PostConditionType.PoX &&
+    postConditionAddress &&
+    postConditionConditionCode &&
+    isPoxConditionCode(postConditionConditionCode)
+  ) {
+    postCondition = {
+      type: 'pox-postcondition',
+      address: postConditionAddress,
+      condition: poxConditionCodeToComparator(postConditionConditionCode),
+    } as PoxPostCondition;
+  } else if (
     postConditionType !== PostConditionType.STX &&
     postConditionType !== PostConditionType.Fungible &&
-    postConditionType !== PostConditionType.NonFungible
+    postConditionType !== PostConditionType.NonFungible &&
+    postConditionType !== PostConditionType.Staking &&
+    postConditionType !== PostConditionType.PoX
   ) {
     throw new Error(`There is no post condition type that matches ${postConditionType}`);
   }
 
-  return [postCondition as PostCondition];
+  // Nothing matched: return an empty list rather than [undefined], which
+  // callContract would otherwise try to serialize
+  return postCondition ? [postCondition as PostCondition] : [];
 }
 
 export const checkFunctionParameters = (fn: ClarityAbiFunction, values: FunctionFormikState) => {
@@ -258,6 +336,16 @@ export const checkPostConditionParameters = (
       errors[key] = 'Invalid Stacks address';
       return;
     }
+    if (
+      key === 'postConditionConditionCode' &&
+      !isConditionCodeValidForType(
+        formikState.postConditionType as PostConditionType,
+        formikState[key]
+      )
+    ) {
+      errors[key] = 'Condition code does not match the selected post condition type';
+      return;
+    }
     if (key === 'postConditionAmount') {
       if (
         typeof formikState[key] !== 'number' ||
@@ -289,6 +377,26 @@ function getPostConditionConditionCodeOptions(
       {
         label: 'Sends',
         value: NonFungibleConditionCode.Sends,
+      },
+      {
+        label: 'May send',
+        value: NonFungibleConditionCode.MaybeSent,
+      },
+    ];
+  }
+  if (postConditionType === PostConditionType.PoX) {
+    return [
+      {
+        label: 'Will not perform',
+        value: PoxConditionCode.WillNotPerform,
+      },
+      {
+        label: 'May perform',
+        value: PoxConditionCode.MayPerform,
+      },
+      {
+        label: 'Will perform',
+        value: PoxConditionCode.WillPerform,
       },
     ];
   }
@@ -367,15 +475,6 @@ export function PostConditionTypeMenu({ onChange }: { onChange: (option: any) =>
     label: 'Select a post condition',
     value: undefined,
   });
-  const options = useMemo(
-    () => [
-      { label: 'STX Post Condition', value: PostConditionType.STX },
-      { label: 'Fungible Post Condition', value: PostConditionType.Fungible },
-      { label: 'Non-Fungible Post Condition', value: PostConditionType.NonFungible },
-    ],
-    []
-  );
-
   return (
     <MenuRoot>
       <Flex gap={2} alignItems="center">
@@ -394,7 +493,7 @@ export function PostConditionTypeMenu({ onChange }: { onChange: (option: any) =>
         </MenuTrigger>
       </Flex>
       <MenuContent>
-        {options.map(option => (
+        {PostConditionOptions.map(option => (
           <MenuItem
             key={option.label}
             onClick={e => {
@@ -425,7 +524,7 @@ export function PostConditionForm({
 }) {
   return (
     <>
-      {values.postConditionMode === PostConditionMode.Deny && (
+      {values.postConditionMode !== PostConditionMode.Allow && (
         <Stack gap={4}>
           <Stack gap={2}>
             <PostConditionTypeMenu

--- a/src/app/sandbox/components/ContractCall/__tests__/PostConditionForm.test.ts
+++ b/src/app/sandbox/components/ContractCall/__tests__/PostConditionForm.test.ts
@@ -1,7 +1,12 @@
-import { FungibleConditionCode, PostConditionMode, PostConditionType } from '@stacks/transactions';
+import {
+  FungibleConditionCode,
+  PostConditionMode,
+  PostConditionType,
+  PoxConditionCode,
+} from '@stacks/transactions';
 
 import { FunctionFormikState } from '../FunctionView';
-import { checkPostConditionParameters } from '../PostConditionForm';
+import { checkPostConditionParameters, getPostCondition } from '../PostConditionForm';
 
 describe('checkPostConditionParameters', () => {
   // TODO: fix this test
@@ -118,5 +123,39 @@ describe('checkPostConditionParameters', () => {
       postConditionAddress: 'Invalid Stacks address',
       postConditionAssetContractName: 'Asset Contract Name is required',
     });
+  });
+});
+
+describe('getPostCondition', () => {
+  const address = 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7';
+
+  it('builds the pox-5 staking and pox post conditions', () => {
+    expect(
+      getPostCondition({
+        postConditionType: PostConditionType.Staking,
+        postConditionAddress: address,
+        postConditionConditionCode: FungibleConditionCode.LessEqual,
+        postConditionAmount: 1100000,
+      })
+    ).toEqual([{ type: 'staking-postcondition', address, condition: 'lte', amount: '1100000' }]);
+
+    expect(
+      getPostCondition({
+        postConditionType: PostConditionType.PoX,
+        postConditionAddress: address,
+        postConditionConditionCode: PoxConditionCode.WillPerform,
+      })
+    ).toEqual([{ type: 'pox-postcondition', address, condition: 'will-perform' }]);
+  });
+
+  it('returns an empty list rather than [undefined] when nothing matches', () => {
+    expect(
+      getPostCondition({
+        postConditionType: PostConditionType.PoX,
+        postConditionAddress: address,
+        // a code left behind by an earlier fungible selection
+        postConditionConditionCode: FungibleConditionCode.Equal,
+      })
+    ).toEqual([]);
   });
 });

--- a/src/app/sandbox/components/ContractCall/__tests__/PostConditionForm.test.ts
+++ b/src/app/sandbox/components/ContractCall/__tests__/PostConditionForm.test.ts
@@ -153,7 +153,6 @@ describe('getPostCondition', () => {
       getPostCondition({
         postConditionType: PostConditionType.PoX,
         postConditionAddress: address,
-        // a code left behind by an earlier fungible selection
         postConditionConditionCode: FungibleConditionCode.Equal,
       })
     ).toEqual([]);

--- a/src/app/sandbox/utils/walletTransactions.ts
+++ b/src/app/sandbox/utils/walletTransactions.ts
@@ -86,10 +86,6 @@ export const callContract = async (params: {
       functionName: params.functionName,
       functionArgs: clarityArgs,
       network: params.network || 'mainnet',
-      // Serialize here rather than handing objects to connect: 8.1.9 only knows
-      // stx/ft/nft post-conditions and routes anything else — the pox-5 staking
-      // and pox types — through Cl.serialize, which throws. This produces the
-      // same hex connect would, and stays correct once it can do it itself.
       postConditions: params.postConditions?.map(postCondition =>
         typeof postCondition === 'string' ? postCondition : postConditionToHex(postCondition)
       ),

--- a/src/app/sandbox/utils/walletTransactions.ts
+++ b/src/app/sandbox/utils/walletTransactions.ts
@@ -4,7 +4,7 @@ import { logError } from '@/common/utils/error-utils';
 
 import { request } from '@stacks/connect';
 import { NetworkString } from '@stacks/connect/dist/types/methods';
-import { Cl, PostCondition, PostConditionModeName } from '@stacks/transactions';
+import { Cl, PostCondition, PostConditionModeName, postConditionToHex } from '@stacks/transactions';
 
 const formatClarityArgs = (args: any[]): any[] => {
   return args.map(arg => {
@@ -86,7 +86,13 @@ export const callContract = async (params: {
       functionName: params.functionName,
       functionArgs: clarityArgs,
       network: params.network || 'mainnet',
-      postConditions: params.postConditions,
+      // Serialize here rather than handing objects to connect: 8.1.9 only knows
+      // stx/ft/nft post-conditions and routes anything else — the pox-5 staking
+      // and pox types — through Cl.serialize, which throws. This produces the
+      // same hex connect would, and stays correct once it can do it itself.
+      postConditions: params.postConditions?.map(postCondition =>
+        typeof postCondition === 'string' ? postCondition : postConditionToHex(postCondition)
+      ),
       postConditionMode: params.postConditionMode,
     });
 

--- a/src/app/txid/[txId]/redesign/function-called/FunctionCallForm.tsx
+++ b/src/app/txid/[txId]/redesign/function-called/FunctionCallForm.tsx
@@ -5,6 +5,12 @@ import { Select } from '@/common/components/Select';
 import { useGlobalContext } from '@/common/context/useGlobalContext';
 import { logError } from '@/common/utils/error-utils';
 import { getConnectNetworkString } from '@/common/utils/network-utils';
+import {
+  postConditionModeDescriptions,
+  postConditionModeFromName,
+  postConditionModeNames,
+  postConditionModeOptions,
+} from '@/common/utils/post-condition-mode-utils';
 import { InvalidFunctionType, getInvalidFunctionType, showFn } from '@/common/utils/sandbox';
 import { Alert } from '@/components/ui/alert';
 import { Button } from '@/ui/Button';
@@ -147,22 +153,12 @@ export const FunctionCallForm: FC<FunctionCallFormProps> = ({
                     Post-conditions:
                   </Text>
                   <Select
-                    defaultValue={['allow']}
-                    items={[
-                      {
-                        value: 'allow',
-                        label: 'Allow mode',
-                      },
-                      {
-                        value: 'deny',
-                        label: 'Deny mode',
-                      },
-                    ]}
+                    defaultValue={[postConditionModeNames[PostConditionMode.Allow]]}
+                    items={postConditionModeOptions}
+                    label="Post-condition mode"
                     onValueChange={details => {
-                      const postConditionMode =
-                        details.value[0] === 'allow'
-                          ? PostConditionMode.Allow
-                          : PostConditionMode.Deny;
+                      const postConditionMode = postConditionModeFromName(details.value[0]);
+                      if (postConditionMode == null) return;
                       setFieldValue('postConditionMode', postConditionMode);
                     }}
                     size="sm"
@@ -170,7 +166,11 @@ export const FunctionCallForm: FC<FunctionCallFormProps> = ({
                 </Flex>
                 <Alert
                   status="neutral"
-                  description={`In the context of post-conditions, \"allow mode\" and \"deny mode\" determine how transactions are processed when they don't exactly match the specified post-conditions. Allow mode permits transactions that satisfy the post-condition criteria, while deny mode restricts transactions to only the criteria explicitly listed in the post-conditions; anything not listed will cause the transaction to fail. Learn more about post-conditions.`}
+                  description={
+                    postConditionModeDescriptions[
+                      values.postConditionMode ?? PostConditionMode.Allow
+                    ]
+                  }
                 />
               </Stack>
             )}

--- a/src/app/txid/[txId]/redesign/function-called/PostConditionForm.tsx
+++ b/src/app/txid/[txId]/redesign/function-called/PostConditionForm.tsx
@@ -38,10 +38,6 @@ export function PostConditionForm({
     ): T extends React.ChangeEvent<any> ? void : (e: string | React.ChangeEvent<any>) => void;
   };
 }) {
-  // Formik holds whatever the Select wrote, which can be the string form of the
-  // enum. getPostConditionConditionCodeOptions compares with ===, so without this
-  // coercion PoX and Non-Fungible silently fall through to the fungible codes and
-  // their post-conditions can never be built.
   const postConditionType =
     values.postConditionType != null
       ? (Number(values.postConditionType) as PostConditionType)

--- a/src/app/txid/[txId]/redesign/function-called/PostConditionForm.tsx
+++ b/src/app/txid/[txId]/redesign/function-called/PostConditionForm.tsx
@@ -5,7 +5,7 @@ import { Box, Field, Stack } from '@chakra-ui/react';
 import { FormikErrors } from 'formik';
 import { ChangeEvent, useMemo } from 'react';
 
-import { PostConditionMode } from '@stacks/transactions';
+import { PostConditionMode, PostConditionType } from '@stacks/transactions';
 
 import { FormikSetFieldValueFunction, FunctionFormikState } from './FunctionCallForm';
 import {
@@ -38,21 +38,26 @@ export function PostConditionForm({
     ): T extends React.ChangeEvent<any> ? void : (e: string | React.ChangeEvent<any>) => void;
   };
 }) {
+  // Formik holds whatever the Select wrote, which can be the string form of the
+  // enum. getPostConditionConditionCodeOptions compares with ===, so without this
+  // coercion PoX and Non-Fungible silently fall through to the fungible codes and
+  // their post-conditions can never be built.
+  const postConditionType =
+    values.postConditionType != null
+      ? (Number(values.postConditionType) as PostConditionType)
+      : undefined;
+
   const postConditionConditionCodeOptions = useMemo(() => {
-    return values.postConditionType != null
-      ? getPostConditionConditionCodeOptions(values.postConditionType)
-      : [];
-  }, [values.postConditionType]);
+    return postConditionType != null ? getPostConditionConditionCodeOptions(postConditionType) : [];
+  }, [postConditionType]);
 
   const postConditionTypeParameters = useMemo(() => {
-    return values.postConditionType != null
-      ? postConditionParameterMap[values.postConditionType]
-      : [];
-  }, [values.postConditionType]);
+    return postConditionType != null ? postConditionParameterMap[postConditionType] : [];
+  }, [postConditionType]);
 
   return (
     <>
-      {values.postConditionMode === PostConditionMode.Deny && (
+      {values.postConditionMode !== PostConditionMode.Allow && (
         <Stack gap={4}>
           <Stack gap={2}>
             <Select<PostConditionTypeValue, PostConditionTypeLabel>

--- a/src/app/txid/[txId]/redesign/function-called/__tests__/function-call-post-condition-utils.test.ts
+++ b/src/app/txid/[txId]/redesign/function-called/__tests__/function-call-post-condition-utils.test.ts
@@ -482,7 +482,6 @@ describe('condition code / post condition type pairing', () => {
       postConditionMode: PostConditionMode.Deny,
       postConditionType: PostConditionType.PoX,
       postConditionAddress: 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7',
-      // left behind by an earlier fungible selection
       postConditionConditionCode: FungibleConditionCode.Equal,
     });
 
@@ -493,9 +492,6 @@ describe('condition code / post condition type pairing', () => {
 });
 
 describe('wallet serialization', () => {
-  // connect 8.1.9 cannot serialize the pox-5 types itself, so callContract hands it
-  // hex. These assert the objects we build survive that step, and carry the wire
-  // type ids SIP-044 specifies: 0x03 staking, 0x04 pox.
   it('serializes a staking post condition to wire type 0x03', () => {
     const pc = getPostCondition({
       postConditionType: PostConditionType.Staking,

--- a/src/app/txid/[txId]/redesign/function-called/__tests__/function-call-post-condition-utils.test.ts
+++ b/src/app/txid/[txId]/redesign/function-called/__tests__/function-call-post-condition-utils.test.ts
@@ -3,19 +3,25 @@ import {
   NonFungibleConditionCode,
   PostConditionMode,
   PostConditionType,
+  PoxConditionCode,
+  postConditionToHex,
 } from '@stacks/transactions';
 
 import {
+  PostConditionBuilderParameters,
   PostConditionParameters,
   checkPostConditionParameters,
   extractPostConditionParams,
   fungibleConditionCodeToComparator,
   getPostCondition,
   getPostConditionConditionCodeOptions,
+  isConditionCodeValidForType,
   isFungibleConditionCode,
   isNonFungibleConditionCode,
   isPostConditionParameter,
+  isPoxConditionCode,
   nonFungibleConditionCodeToComparator,
+  poxConditionCodeToComparator,
 } from '../function-call-post-condition-params-utils';
 
 describe('Type Guard Functions', () => {
@@ -186,7 +192,7 @@ describe('Validation Functions', () => {
 describe('Post Condition Creation', () => {
   describe('getPostCondition', () => {
     it('should create STX post condition', () => {
-      const params: PostConditionParameters = {
+      const params: PostConditionBuilderParameters = {
         postConditionType: PostConditionType.STX,
         postConditionAddress: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
         postConditionConditionCode: FungibleConditionCode.Equal,
@@ -202,7 +208,7 @@ describe('Post Condition Creation', () => {
     });
 
     it('should create Fungible post condition', () => {
-      const params: PostConditionParameters = {
+      const params: PostConditionBuilderParameters = {
         postConditionType: PostConditionType.Fungible,
         postConditionAddress: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
         postConditionConditionCode: FungibleConditionCode.Greater,
@@ -222,7 +228,7 @@ describe('Post Condition Creation', () => {
     });
 
     it('should create Non-Fungible post condition', () => {
-      const params: PostConditionParameters = {
+      const params: PostConditionBuilderParameters = {
         postConditionType: PostConditionType.NonFungible,
         postConditionAddress: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
         postConditionConditionCode: NonFungibleConditionCode.Sends,
@@ -244,7 +250,7 @@ describe('Post Condition Creation', () => {
     });
 
     it('should throw error for invalid STX post condition (missing parameters)', () => {
-      const params: PostConditionParameters = {
+      const params: PostConditionBuilderParameters = {
         postConditionType: PostConditionType.STX,
         postConditionAddress: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
         // Missing condition code and amount
@@ -254,7 +260,7 @@ describe('Post Condition Creation', () => {
     });
 
     it('should throw error for invalid amount (not uint128)', () => {
-      const params: PostConditionParameters = {
+      const params: PostConditionBuilderParameters = {
         postConditionType: PostConditionType.STX,
         postConditionAddress: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
         postConditionConditionCode: FungibleConditionCode.Equal,
@@ -270,10 +276,11 @@ describe('Utility Functions', () => {
   describe('getPostConditionConditionCodeOptions', () => {
     it('should return non-fungible options for NonFungible post condition type', () => {
       const options = getPostConditionConditionCodeOptions(PostConditionType.NonFungible);
-      expect(options).toHaveLength(2);
+      expect(options).toHaveLength(3);
       expect(options).toEqual([
         { label: 'Does not send', value: 'does-not-send' },
         { label: 'Sends', value: 'sends' },
+        { label: 'May send', value: 'may-send' },
       ]);
     });
 
@@ -376,5 +383,137 @@ describe('Utility Functions', () => {
         postConditionAssetName: undefined,
       });
     });
+  });
+});
+
+describe('pox-5 post conditions', () => {
+  it('recognizes PoX condition codes and keeps them distinct from asset codes', () => {
+    expect(isPoxConditionCode(PoxConditionCode.MayPerform)).toBe(true);
+    expect(isPoxConditionCode(FungibleConditionCode.Equal)).toBe(false);
+    expect(isPoxConditionCode(NonFungibleConditionCode.MaybeSent)).toBe(false);
+  });
+
+  it('maps PoX condition codes to comparators', () => {
+    expect(poxConditionCodeToComparator(PoxConditionCode.WillNotPerform)).toBe('will-not-perform');
+    expect(poxConditionCodeToComparator(PoxConditionCode.MayPerform)).toBe('may-perform');
+    expect(poxConditionCodeToComparator(PoxConditionCode.WillPerform)).toBe('will-perform');
+  });
+
+  it('maps the new NFT maybe-sent comparator', () => {
+    expect(nonFungibleConditionCodeToComparator(NonFungibleConditionCode.MaybeSent)).toBe(
+      'maybe-sent'
+    );
+  });
+
+  it('builds a staking post condition', () => {
+    const params: PostConditionBuilderParameters = {
+      postConditionType: PostConditionType.Staking,
+      postConditionAddress: 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7',
+      postConditionConditionCode: FungibleConditionCode.LessEqual,
+      postConditionAmount: 1100000,
+    };
+
+    expect(getPostCondition(params)).toEqual({
+      type: 'staking-postcondition',
+      address: 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7',
+      condition: 'lte',
+      amount: '1100000',
+    });
+  });
+
+  it('builds a pox post condition, which carries no amount', () => {
+    const params: PostConditionBuilderParameters = {
+      postConditionType: PostConditionType.PoX,
+      postConditionAddress: 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7',
+      postConditionConditionCode: PoxConditionCode.WillPerform,
+    };
+
+    expect(getPostCondition(params)).toEqual({
+      type: 'pox-postcondition',
+      address: 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7',
+      condition: 'will-perform',
+    });
+  });
+
+  it('offers PoX condition codes for the PoX post condition type', () => {
+    expect(getPostConditionConditionCodeOptions(PostConditionType.PoX).map(o => o.value)).toEqual([
+      'will-not-perform',
+      'may-perform',
+      'will-perform',
+    ]);
+  });
+
+  it('validates originator mode like deny mode, not like allow mode', () => {
+    const params = {
+      postConditionMode: PostConditionMode.Originator,
+    } as PostConditionParameters;
+
+    expect(checkPostConditionParameters(params)).toEqual({
+      postConditionType: 'Post condition type is required',
+    });
+  });
+});
+
+describe('condition code / post condition type pairing', () => {
+  it('accepts fungible codes for stx, fungible and staking', () => {
+    [PostConditionType.STX, PostConditionType.Fungible, PostConditionType.Staking].forEach(type => {
+      expect(isConditionCodeValidForType(type, FungibleConditionCode.Equal)).toBe(true);
+      expect(isConditionCodeValidForType(type, PoxConditionCode.MayPerform)).toBe(false);
+    });
+  });
+
+  it('accepts only its own codes for non-fungible and pox', () => {
+    expect(
+      isConditionCodeValidForType(PostConditionType.NonFungible, NonFungibleConditionCode.MaybeSent)
+    ).toBe(true);
+    expect(
+      isConditionCodeValidForType(PostConditionType.NonFungible, FungibleConditionCode.Equal)
+    ).toBe(false);
+    expect(isConditionCodeValidForType(PostConditionType.PoX, PoxConditionCode.WillPerform)).toBe(
+      true
+    );
+    expect(isConditionCodeValidForType(PostConditionType.PoX, FungibleConditionCode.Equal)).toBe(
+      false
+    );
+  });
+
+  it('reports a code left over from a previously selected type', () => {
+    const errors = checkPostConditionParameters({
+      postConditionMode: PostConditionMode.Deny,
+      postConditionType: PostConditionType.PoX,
+      postConditionAddress: 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7',
+      // left behind by an earlier fungible selection
+      postConditionConditionCode: FungibleConditionCode.Equal,
+    });
+
+    expect(errors.postConditionConditionCode).toBe(
+      'Condition code does not match the selected post condition type'
+    );
+  });
+});
+
+describe('wallet serialization', () => {
+  // connect 8.1.9 cannot serialize the pox-5 types itself, so callContract hands it
+  // hex. These assert the objects we build survive that step, and carry the wire
+  // type ids SIP-044 specifies: 0x03 staking, 0x04 pox.
+  it('serializes a staking post condition to wire type 0x03', () => {
+    const pc = getPostCondition({
+      postConditionType: PostConditionType.Staking,
+      postConditionAddress: 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7',
+      postConditionConditionCode: FungibleConditionCode.LessEqual,
+      postConditionAmount: 1100000,
+    });
+
+    expect(postConditionToHex(pc!).startsWith('03')).toBe(true);
+  });
+
+  it('serializes a pox post condition to wire type 0x04', () => {
+    const pc = getPostCondition({
+      postConditionType: PostConditionType.PoX,
+      postConditionAddress: 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7',
+      postConditionConditionCode: PoxConditionCode.WillPerform,
+    });
+
+    expect(postConditionToHex(pc!).startsWith('04')).toBe(true);
   });
 });

--- a/src/app/txid/[txId]/redesign/function-called/function-call-function-params-utils.ts
+++ b/src/app/txid/[txId]/redesign/function-called/function-call-function-params-utils.ts
@@ -9,6 +9,7 @@ import {
 import { encodeOptional, encodeOptionalTuple, encodeTuple, getTuple } from '@/app/sandbox/utils';
 import { callContract } from '@/app/sandbox/utils/walletTransactions';
 import { isUint128 } from '@/common/utils/number-utils';
+import { postConditionModeNames } from '@/common/utils/post-condition-mode-utils';
 import { QueryClient } from '@tanstack/react-query';
 
 import { asciiToBytes, bytesToHex } from '@stacks/common';
@@ -121,7 +122,7 @@ export async function handlePublicFunctionCall(
   postConditionParams: PostConditionParameters,
   { contractId, fnAbi, network, queryClient }: ContractCallDependencies
 ): Promise<void> {
-  const postCondition = shouldUsePostConditions(postConditionParams.postConditionMode!)
+  const postCondition = shouldUsePostConditions(postConditionParams.postConditionMode)
     ? getPostCondition(postConditionParams)
     : undefined;
   const functionArgs = Object.values(final);
@@ -132,8 +133,7 @@ export async function handlePublicFunctionCall(
     functionArgs,
     network: network,
     postConditions: postCondition ? [postCondition] : undefined,
-    postConditionMode:
-      postConditionParams.postConditionMode === PostConditionMode.Allow ? 'allow' : 'deny',
+    postConditionMode: postConditionModeNames[postConditionParams.postConditionMode],
   }).then(() => {
     void queryClient.invalidateQueries({ queryKey: ['addressMempoolTxsInfinite'] });
   });

--- a/src/app/txid/[txId]/redesign/function-called/function-call-post-condition-params-utils.ts
+++ b/src/app/txid/[txId]/redesign/function-called/function-call-post-condition-params-utils.ts
@@ -88,10 +88,6 @@ export function nonFungibleConditionCodeToComparator(
   }
 }
 
-// STX, Fungible and Staking all take fungible condition codes; NonFungible and PoX
-// have their own. Without this check a code left over from a previously selected
-// type passes validation, matches no branch in getPostCondition, and the call is
-// submitted in deny mode with no post-conditions at all.
 export function isConditionCodeValidForType(
   postConditionType: PostConditionType,
   code: PostConditionConditionCode
@@ -106,8 +102,6 @@ export function isConditionCodeValidForType(
 }
 
 export interface PostConditionParameters {
-  // Required: both forms always initialize it, and leaving it optional forced
-  // every consumer into a fallback, one of which silently downgraded Deny to Allow
   postConditionMode: PostConditionMode;
   postConditionType?: PostConditionType;
   postConditionAddress?: string;
@@ -143,8 +137,6 @@ export const postConditionParameterMap: Record<
     'postConditionAssetContractName',
     'postConditionAssetName',
   ],
-  // pox-5 staking and PoX post-conditions constrain the principal itself rather
-  // than an asset, so they take no asset parameters
   [PostConditionType.Staking]: [
     'postConditionAddress',
     'postConditionConditionCode',
@@ -153,7 +145,6 @@ export const postConditionParameterMap: Record<
   [PostConditionType.PoX]: ['postConditionAddress', 'postConditionConditionCode'],
 };
 
-// Building a post condition doesn't depend on the mode; only the form does
 export type PostConditionBuilderParameters = Omit<PostConditionParameters, 'postConditionMode'>;
 
 export const postConditionParametersThatUseSelect: (keyof PostConditionParameters)[] = [
@@ -388,12 +379,10 @@ export function getPostCondition(
     return createNonFungiblePostCondition(postConditionParameters);
   }
 
-  // Staking Post Condition (pox-5)
   if (validateStakingPostConditionParams(postConditionParameters)) {
     return createStakingPostCondition(postConditionParameters);
   }
 
-  // PoX Post Condition (pox-5)
   if (validatePoxPostConditionParams(postConditionParameters)) {
     return createPoxPostCondition(postConditionParameters);
   }
@@ -493,9 +482,6 @@ export const PostConditionTypeValueMap: Record<PostConditionType, PostConditionT
   [PostConditionType.PoX]: 'pox-post-condition',
 };
 
-// Spelled out rather than reversed: `reverseRecord` goes through `Object.entries`,
-// which stringifies the numeric enum values, and a string type silently fails every
-// `=== PostConditionType.X` comparison in getPostCondition.
 export const PostConditionTypeValueMapReversed: Record<PostConditionTypeValue, PostConditionType> =
   {
     'stx-post-condition': PostConditionType.STX,
@@ -588,7 +574,6 @@ export const PostConditionConditionCodeValueMap: Record<
   [PoxConditionCode.WillPerform]: 'will-perform',
 };
 
-// Spelled out for the same reason as PostConditionTypeValueMapReversed above
 export const PostConditionConditionCodeValueMapReversed: Record<
   PostConditionConditionCodeValue,
   PostConditionConditionCode
@@ -691,8 +676,6 @@ export function extractPostConditionParams(values: FunctionFormikState): PostCon
   } = values;
 
   return {
-    // Fall back to the most restrictive mode: an absent mode must never widen
-    // what a signed transaction is allowed to move
     postConditionMode:
       postConditionMode != null ? Number(postConditionMode) : PostConditionMode.Deny,
     postConditionType: postConditionType != null ? Number(postConditionType) : undefined,

--- a/src/app/txid/[txId]/redesign/function-called/function-call-post-condition-params-utils.ts
+++ b/src/app/txid/[txId]/redesign/function-called/function-call-post-condition-params-utils.ts
@@ -1,6 +1,5 @@
 import { logError } from '@/common/utils/error-utils';
 import { isUint128 } from '@/common/utils/number-utils';
-import { reverseRecord } from '@/common/utils/object-utils';
 
 import {
   Cl,
@@ -13,13 +12,20 @@ import {
   PostCondition,
   PostConditionMode,
   PostConditionType,
+  PoxComparator,
+  PoxConditionCode,
+  PoxPostCondition,
+  StakingPostCondition,
   StxPostCondition,
   validateStacksAddress,
 } from '@stacks/transactions';
 
 import { FunctionFormikState } from './FunctionCallForm';
 
-export type PostConditionConditionCode = FungibleConditionCode | NonFungibleConditionCode;
+export type PostConditionConditionCode =
+  | FungibleConditionCode
+  | NonFungibleConditionCode
+  | PoxConditionCode;
 
 export function isFungibleConditionCode(
   code: PostConditionConditionCode
@@ -50,6 +56,23 @@ export function fungibleConditionCodeToComparator(code: FungibleConditionCode): 
   }
 }
 
+export function isPoxConditionCode(code: PostConditionConditionCode): code is PoxConditionCode {
+  return Object.values(PoxConditionCode).includes(code as PoxConditionCode);
+}
+
+export function poxConditionCodeToComparator(code: PoxConditionCode): PoxComparator {
+  switch (code) {
+    case PoxConditionCode.WillNotPerform:
+      return 'will-not-perform';
+    case PoxConditionCode.MayPerform:
+      return 'may-perform';
+    case PoxConditionCode.WillPerform:
+      return 'will-perform';
+    default:
+      return 'will-perform';
+  }
+}
+
 export function nonFungibleConditionCodeToComparator(
   code: NonFungibleConditionCode
 ): NonFungibleComparator {
@@ -58,13 +81,34 @@ export function nonFungibleConditionCodeToComparator(
       return 'sent';
     case NonFungibleConditionCode.DoesNotSend:
       return 'not-sent';
+    case NonFungibleConditionCode.MaybeSent:
+      return 'maybe-sent';
     default:
       return 'sent';
   }
 }
 
+// STX, Fungible and Staking all take fungible condition codes; NonFungible and PoX
+// have their own. Without this check a code left over from a previously selected
+// type passes validation, matches no branch in getPostCondition, and the call is
+// submitted in deny mode with no post-conditions at all.
+export function isConditionCodeValidForType(
+  postConditionType: PostConditionType,
+  code: PostConditionConditionCode
+): boolean {
+  if (postConditionType === PostConditionType.NonFungible) {
+    return isNonFungibleConditionCode(code);
+  }
+  if (postConditionType === PostConditionType.PoX) {
+    return isPoxConditionCode(code);
+  }
+  return isFungibleConditionCode(code);
+}
+
 export interface PostConditionParameters {
-  postConditionMode?: PostConditionMode;
+  // Required: both forms always initialize it, and leaving it optional forced
+  // every consumer into a fallback, one of which silently downgraded Deny to Allow
+  postConditionMode: PostConditionMode;
   postConditionType?: PostConditionType;
   postConditionAddress?: string;
   postConditionConditionCode?: PostConditionConditionCode;
@@ -99,7 +143,18 @@ export const postConditionParameterMap: Record<
     'postConditionAssetContractName',
     'postConditionAssetName',
   ],
+  // pox-5 staking and PoX post-conditions constrain the principal itself rather
+  // than an asset, so they take no asset parameters
+  [PostConditionType.Staking]: [
+    'postConditionAddress',
+    'postConditionConditionCode',
+    'postConditionAmount',
+  ],
+  [PostConditionType.PoX]: ['postConditionAddress', 'postConditionConditionCode'],
 };
+
+// Building a post condition doesn't depend on the mode; only the form does
+export type PostConditionBuilderParameters = Omit<PostConditionParameters, 'postConditionMode'>;
 
 export const postConditionParametersThatUseSelect: (keyof PostConditionParameters)[] = [
   'postConditionMode',
@@ -134,7 +189,7 @@ export const postConditionParameterLabels: Record<string, string> = {
 };
 
 // Validation functions for each post condition type
-function validateStxPostConditionParams(params: PostConditionParameters): boolean {
+function validateStxPostConditionParams(params: PostConditionBuilderParameters): boolean {
   const {
     postConditionType,
     postConditionAddress,
@@ -152,7 +207,7 @@ function validateStxPostConditionParams(params: PostConditionParameters): boolea
   );
 }
 
-function validateFungiblePostConditionParams(params: PostConditionParameters): boolean {
+function validateFungiblePostConditionParams(params: PostConditionBuilderParameters): boolean {
   const {
     postConditionType,
     postConditionAddress,
@@ -176,7 +231,7 @@ function validateFungiblePostConditionParams(params: PostConditionParameters): b
   );
 }
 
-function validateNonFungiblePostConditionParams(params: PostConditionParameters): boolean {
+function validateNonFungiblePostConditionParams(params: PostConditionBuilderParameters): boolean {
   const {
     postConditionType,
     postConditionAddress,
@@ -197,14 +252,45 @@ function validateNonFungiblePostConditionParams(params: PostConditionParameters)
   );
 }
 
+function validateStakingPostConditionParams(params: PostConditionBuilderParameters): boolean {
+  const {
+    postConditionType,
+    postConditionAddress,
+    postConditionConditionCode,
+    postConditionAmount,
+  } = params;
+
+  return (
+    postConditionType === PostConditionType.Staking &&
+    !!postConditionAddress &&
+    !!postConditionConditionCode &&
+    postConditionAmount != null &&
+    isUint128(postConditionAmount) &&
+    isFungibleConditionCode(postConditionConditionCode)
+  );
+}
+
+function validatePoxPostConditionParams(params: PostConditionBuilderParameters): boolean {
+  const { postConditionType, postConditionAddress, postConditionConditionCode } = params;
+
+  return (
+    postConditionType === PostConditionType.PoX &&
+    !!postConditionAddress &&
+    !!postConditionConditionCode &&
+    isPoxConditionCode(postConditionConditionCode)
+  );
+}
+
 enum PCType {
   STX = 'stx-postcondition',
   Fungible = 'ft-postcondition',
   NonFungible = 'nft-postcondition',
+  Staking = 'staking-postcondition',
+  PoX = 'pox-postcondition',
 }
 
 // Post condition creation functions
-function createStxPostCondition(params: PostConditionParameters): StxPostCondition {
+function createStxPostCondition(params: PostConditionBuilderParameters): StxPostCondition {
   const { postConditionAddress, postConditionConditionCode, postConditionAmount } = params;
 
   return {
@@ -217,7 +303,9 @@ function createStxPostCondition(params: PostConditionParameters): StxPostConditi
   } as StxPostCondition;
 }
 
-function createFungiblePostCondition(params: PostConditionParameters): FungiblePostCondition {
+function createFungiblePostCondition(
+  params: PostConditionBuilderParameters
+): FungiblePostCondition {
   const {
     postConditionAddress,
     postConditionConditionCode,
@@ -238,7 +326,9 @@ function createFungiblePostCondition(params: PostConditionParameters): FungibleP
   } as FungiblePostCondition;
 }
 
-function createNonFungiblePostCondition(params: PostConditionParameters): NonFungiblePostCondition {
+function createNonFungiblePostCondition(
+  params: PostConditionBuilderParameters
+): NonFungiblePostCondition {
   const {
     postConditionAddress,
     postConditionConditionCode,
@@ -257,8 +347,31 @@ function createNonFungiblePostCondition(params: PostConditionParameters): NonFun
     assetId: Cl.stringUtf8(postConditionAssetName!),
   } as NonFungiblePostCondition;
 }
+function createStakingPostCondition(params: PostConditionBuilderParameters): StakingPostCondition {
+  const { postConditionAddress, postConditionConditionCode, postConditionAmount } = params;
+
+  return {
+    type: PCType.Staking,
+    address: postConditionAddress!,
+    condition: fungibleConditionCodeToComparator(
+      postConditionConditionCode as FungibleConditionCode
+    ),
+    amount: postConditionAmount!.toString(),
+  } as StakingPostCondition;
+}
+
+function createPoxPostCondition(params: PostConditionBuilderParameters): PoxPostCondition {
+  const { postConditionAddress, postConditionConditionCode } = params;
+
+  return {
+    type: PCType.PoX,
+    address: postConditionAddress!,
+    condition: poxConditionCodeToComparator(postConditionConditionCode as PoxConditionCode),
+  } as PoxPostCondition;
+}
+
 export function getPostCondition(
-  postConditionParameters: PostConditionParameters
+  postConditionParameters: PostConditionBuilderParameters
 ): PostCondition | undefined {
   // STX Post Condition
   if (validateStxPostConditionParams(postConditionParameters)) {
@@ -273,6 +386,16 @@ export function getPostCondition(
   // Non-Fungible Token Post Condition
   if (validateNonFungiblePostConditionParams(postConditionParameters)) {
     return createNonFungiblePostCondition(postConditionParameters);
+  }
+
+  // Staking Post Condition (pox-5)
+  if (validateStakingPostConditionParams(postConditionParameters)) {
+    return createStakingPostCondition(postConditionParameters);
+  }
+
+  // PoX Post Condition (pox-5)
+  if (validatePoxPostConditionParams(postConditionParameters)) {
+    return createPoxPostCondition(postConditionParameters);
   }
 
   // Handle error case
@@ -311,6 +434,16 @@ export const checkPostConditionParameters = (
       errors[key] = 'Invalid Stacks address';
       return;
     }
+    if (
+      key === 'postConditionConditionCode' &&
+      !isConditionCodeValidForType(
+        formikState.postConditionType as PostConditionType,
+        formikState[key]
+      )
+    ) {
+      errors[key] = 'Condition code does not match the selected post condition type';
+      return;
+    }
     if (key === 'postConditionAmount') {
       if (
         typeof formikState[key] !== 'number' ||
@@ -333,27 +466,44 @@ export interface Option<V extends string, L extends string> {
 export type PostConditionTypeLabel =
   | 'STX Post Condition'
   | 'Fungible Post Condition'
-  | 'Non-Fungible Post Condition';
+  | 'Non-Fungible Post Condition'
+  | 'Staking Post Condition'
+  | 'PoX Post Condition';
 
 export const PostConditionTypeLabelMap: Record<PostConditionType, PostConditionTypeLabel> = {
   [PostConditionType.STX]: 'STX Post Condition',
   [PostConditionType.Fungible]: 'Fungible Post Condition',
   [PostConditionType.NonFungible]: 'Non-Fungible Post Condition',
+  [PostConditionType.Staking]: 'Staking Post Condition',
+  [PostConditionType.PoX]: 'PoX Post Condition',
 };
 
 export type PostConditionTypeValue =
   | 'stx-post-condition'
   | 'fungible-post-condition'
-  | 'non-fungible-post-condition';
+  | 'non-fungible-post-condition'
+  | 'staking-post-condition'
+  | 'pox-post-condition';
 
 export const PostConditionTypeValueMap: Record<PostConditionType, PostConditionTypeValue> = {
   [PostConditionType.STX]: 'stx-post-condition',
   [PostConditionType.Fungible]: 'fungible-post-condition',
   [PostConditionType.NonFungible]: 'non-fungible-post-condition',
+  [PostConditionType.Staking]: 'staking-post-condition',
+  [PostConditionType.PoX]: 'pox-post-condition',
 };
 
+// Spelled out rather than reversed: `reverseRecord` goes through `Object.entries`,
+// which stringifies the numeric enum values, and a string type silently fails every
+// `=== PostConditionType.X` comparison in getPostCondition.
 export const PostConditionTypeValueMapReversed: Record<PostConditionTypeValue, PostConditionType> =
-  reverseRecord(PostConditionTypeValueMap);
+  {
+    'stx-post-condition': PostConditionType.STX,
+    'fungible-post-condition': PostConditionType.Fungible,
+    'non-fungible-post-condition': PostConditionType.NonFungible,
+    'staking-post-condition': PostConditionType.Staking,
+    'pox-post-condition': PostConditionType.PoX,
+  };
 
 export const PostConditionTypeOptions = [
   {
@@ -368,16 +518,28 @@ export const PostConditionTypeOptions = [
     label: PostConditionTypeLabelMap[PostConditionType.NonFungible],
     value: PostConditionTypeValueMap[PostConditionType.NonFungible],
   },
+  {
+    label: PostConditionTypeLabelMap[PostConditionType.Staking],
+    value: PostConditionTypeValueMap[PostConditionType.Staking],
+  },
+  {
+    label: PostConditionTypeLabelMap[PostConditionType.PoX],
+    value: PostConditionTypeValueMap[PostConditionType.PoX],
+  },
 ];
 
 export type PostConditionConditionCodeLabel =
   | 'Does not send'
   | 'Sends'
+  | 'May send'
   | 'Equal'
   | 'Greater'
   | 'GreaterEqual'
   | 'Less'
-  | 'LessEqual';
+  | 'LessEqual'
+  | 'Will not perform'
+  | 'May perform'
+  | 'Will perform';
 
 export const PostConditionConditionCodeLabelMap: Record<
   PostConditionConditionCode,
@@ -385,21 +547,29 @@ export const PostConditionConditionCodeLabelMap: Record<
 > = {
   [NonFungibleConditionCode.DoesNotSend]: 'Does not send',
   [NonFungibleConditionCode.Sends]: 'Sends',
+  [NonFungibleConditionCode.MaybeSent]: 'May send',
   [FungibleConditionCode.Equal]: 'Equal',
   [FungibleConditionCode.Greater]: 'Greater',
   [FungibleConditionCode.GreaterEqual]: 'GreaterEqual',
   [FungibleConditionCode.Less]: 'Less',
   [FungibleConditionCode.LessEqual]: 'LessEqual',
+  [PoxConditionCode.WillNotPerform]: 'Will not perform',
+  [PoxConditionCode.MayPerform]: 'May perform',
+  [PoxConditionCode.WillPerform]: 'Will perform',
 };
 
 export type PostConditionConditionCodeValue =
   | 'does-not-send'
   | 'sends'
+  | 'may-send'
   | 'equal'
   | 'greater'
   | 'greater-equal'
   | 'less'
-  | 'less-equal';
+  | 'less-equal'
+  | 'will-not-perform'
+  | 'may-perform'
+  | 'will-perform';
 
 export const PostConditionConditionCodeValueMap: Record<
   PostConditionConditionCode,
@@ -407,17 +577,34 @@ export const PostConditionConditionCodeValueMap: Record<
 > = {
   [NonFungibleConditionCode.DoesNotSend]: 'does-not-send',
   [NonFungibleConditionCode.Sends]: 'sends',
+  [NonFungibleConditionCode.MaybeSent]: 'may-send',
   [FungibleConditionCode.Equal]: 'equal',
   [FungibleConditionCode.Greater]: 'greater',
   [FungibleConditionCode.GreaterEqual]: 'greater-equal',
   [FungibleConditionCode.Less]: 'less',
   [FungibleConditionCode.LessEqual]: 'less-equal',
+  [PoxConditionCode.WillNotPerform]: 'will-not-perform',
+  [PoxConditionCode.MayPerform]: 'may-perform',
+  [PoxConditionCode.WillPerform]: 'will-perform',
 };
 
+// Spelled out for the same reason as PostConditionTypeValueMapReversed above
 export const PostConditionConditionCodeValueMapReversed: Record<
   PostConditionConditionCodeValue,
   PostConditionConditionCode
-> = reverseRecord(PostConditionConditionCodeValueMap);
+> = {
+  'does-not-send': NonFungibleConditionCode.DoesNotSend,
+  sends: NonFungibleConditionCode.Sends,
+  'may-send': NonFungibleConditionCode.MaybeSent,
+  equal: FungibleConditionCode.Equal,
+  greater: FungibleConditionCode.Greater,
+  'greater-equal': FungibleConditionCode.GreaterEqual,
+  less: FungibleConditionCode.Less,
+  'less-equal': FungibleConditionCode.LessEqual,
+  'will-not-perform': PoxConditionCode.WillNotPerform,
+  'may-perform': PoxConditionCode.MayPerform,
+  'will-perform': PoxConditionCode.WillPerform,
+};
 
 export function getPostConditionConditionCodeOptions(
   postConditionType: PostConditionType
@@ -431,6 +618,26 @@ export function getPostConditionConditionCodeOptions(
       {
         label: PostConditionConditionCodeLabelMap[NonFungibleConditionCode.Sends],
         value: PostConditionConditionCodeValueMap[NonFungibleConditionCode.Sends],
+      },
+      {
+        label: PostConditionConditionCodeLabelMap[NonFungibleConditionCode.MaybeSent],
+        value: PostConditionConditionCodeValueMap[NonFungibleConditionCode.MaybeSent],
+      },
+    ];
+  }
+  if (postConditionType === PostConditionType.PoX) {
+    return [
+      {
+        label: PostConditionConditionCodeLabelMap[PoxConditionCode.WillNotPerform],
+        value: PostConditionConditionCodeValueMap[PoxConditionCode.WillNotPerform],
+      },
+      {
+        label: PostConditionConditionCodeLabelMap[PoxConditionCode.MayPerform],
+        value: PostConditionConditionCodeValueMap[PoxConditionCode.MayPerform],
+      },
+      {
+        label: PostConditionConditionCodeLabelMap[PoxConditionCode.WillPerform],
+        value: PostConditionConditionCodeValueMap[PoxConditionCode.WillPerform],
       },
     ];
   }
@@ -484,7 +691,10 @@ export function extractPostConditionParams(values: FunctionFormikState): PostCon
   } = values;
 
   return {
-    postConditionMode: postConditionMode != null ? Number(postConditionMode) : undefined,
+    // Fall back to the most restrictive mode: an absent mode must never widen
+    // what a signed transaction is allowed to move
+    postConditionMode:
+      postConditionMode != null ? Number(postConditionMode) : PostConditionMode.Deny,
     postConditionType: postConditionType != null ? Number(postConditionType) : undefined,
     postConditionAddress,
     postConditionConditionCode:

--- a/src/app/txid/[txId]/redesign/post-conditions/PostConditionsHeader.tsx
+++ b/src/app/txid/[txId]/redesign/post-conditions/PostConditionsHeader.tsx
@@ -30,8 +30,6 @@ export function PostConditionsHeader({
 }: {
   postConditionMode: PostConditionMode | 'originator';
 }) {
-  // A mode the API adds before the explorer knows it should not take down the
-  // whole transaction page
   const { label, description } = postConditionModeMap[postConditionMode] ?? {
     label: postConditionMode,
     description: 'This transaction uses a post-condition mode the explorer does not recognize yet.',

--- a/src/app/txid/[txId]/redesign/post-conditions/PostConditionsHeader.tsx
+++ b/src/app/txid/[txId]/redesign/post-conditions/PostConditionsHeader.tsx
@@ -30,7 +30,12 @@ export function PostConditionsHeader({
 }: {
   postConditionMode: PostConditionMode | 'originator';
 }) {
-  const { label, description } = postConditionModeMap[postConditionMode];
+  // A mode the API adds before the explorer knows it should not take down the
+  // whole transaction page
+  const { label, description } = postConditionModeMap[postConditionMode] ?? {
+    label: postConditionMode,
+    description: 'This transaction uses a post-condition mode the explorer does not recognize yet.',
+  };
   return (
     <Flex
       gap={2.5}

--- a/src/app/txid/[txId]/redesign/post-conditions/PostConditionsTable.tsx
+++ b/src/app/txid/[txId]/redesign/post-conditions/PostConditionsTable.tsx
@@ -26,7 +26,7 @@ import {
   PostConditionAmountCellRenderer,
   PostConditionAmountData,
 } from './PostConditionsTableCellRenderers';
-import { PostConditionWithStaking, getPostConditionCellText } from './post-condition-table-utils';
+import { ExtendedPostCondition, getPostConditionCellText } from './post-condition-table-utils';
 
 enum PostConditionsTableColumns {
   From = 'from',
@@ -58,8 +58,14 @@ const columnDefinitions: ColumnDef<PostConditionsTableData>[] = [
       <EllipsisText textStyle="text-medium-sm">{info.getValue() as string}</EllipsisText>
     ),
     enableSorting: false,
-    minSize: 150,
-    maxSize: 150,
+    // Sized to clear the longest string this column can render — the
+    // "Undefined post condition code" fallback at ~200px, ahead of the new
+    // "Must not perform PoX action" at ~187px. EllipsisText has no tooltip, so
+    // anything that overflows is lost rather than recoverable. The binding case
+    // is the narrow viewport, where the table is space-constrained and the
+    // column is pinned to exactly this width with 8px/side cell padding.
+    minSize: 230,
+    maxSize: 230,
   },
   {
     id: PostConditionsTableColumns.AssetAmount,
@@ -100,7 +106,7 @@ type TxWithPostConditions =
   | MempoolSmartContractTransaction;
 
 export function PostConditionsTable({ tx }: { tx: TxWithPostConditions }) {
-  const postConditions: PostConditionWithStaking[] = tx.post_conditions;
+  const postConditions: ExtendedPostCondition[] = tx.post_conditions;
   const senderAddress = tx.sender_address;
   const isContract = validateStacksContractId(senderAddress);
 

--- a/src/app/txid/[txId]/redesign/post-conditions/PostConditionsTable.tsx
+++ b/src/app/txid/[txId]/redesign/post-conditions/PostConditionsTable.tsx
@@ -58,12 +58,6 @@ const columnDefinitions: ColumnDef<PostConditionsTableData>[] = [
       <EllipsisText textStyle="text-medium-sm">{info.getValue() as string}</EllipsisText>
     ),
     enableSorting: false,
-    // Sized to clear the longest string this column can render — the
-    // "Undefined post condition code" fallback at ~200px, ahead of the new
-    // "Must not perform PoX action" at ~187px. EllipsisText has no tooltip, so
-    // anything that overflows is lost rather than recoverable. The binding case
-    // is the narrow viewport, where the table is space-constrained and the
-    // column is pinned to exactly this width with 8px/side cell padding.
     minSize: 230,
     maxSize: 230,
   },

--- a/src/app/txid/[txId]/redesign/post-conditions/PostConditionsTableCellRenderers.tsx
+++ b/src/app/txid/[txId]/redesign/post-conditions/PostConditionsTableCellRenderers.tsx
@@ -1,9 +1,9 @@
 import { AmountCellRenderer, AssetType } from '@/common/components/table/CommonTableCellRenderers';
 
-import { PostConditionWithStaking, getAmount } from './post-condition-table-utils';
+import { ExtendedPostCondition, getAmount } from './post-condition-table-utils';
 
 export function getAssetTypeFromPostConditionType(
-  postConditionType: PostConditionWithStaking['type']
+  postConditionType: ExtendedPostCondition['type']
 ) {
   switch (postConditionType) {
     case 'stx':
@@ -20,7 +20,7 @@ export function getAssetTypeFromPostConditionType(
 }
 
 export interface PostConditionAmountData {
-  postCondition: PostConditionWithStaking;
+  postCondition: ExtendedPostCondition;
   ftDecimals?: number;
 }
 

--- a/src/app/txid/[txId]/redesign/post-conditions/__tests__/post-condition-table-utils.test.ts
+++ b/src/app/txid/[txId]/redesign/post-conditions/__tests__/post-condition-table-utils.test.ts
@@ -33,6 +33,11 @@ describe('getAmount', () => {
     expect(getAmount(pc)).toBe('1100000');
   });
 
+  test('returns empty string for pox, which has no amount', () => {
+    const pc: any = { type: 'pox', condition_code: 'performed' };
+    expect(getAmount(pc)).toBe('');
+  });
+
   test('returns empty string for unknown type', () => {
     const pc: any = { type: 'unknown', amount: '1000' };
     expect(getAmount(pc)).toBe('');
@@ -54,7 +59,14 @@ describe('getPostConditionCellText', () => {
     expect(getPostConditionCellText('not_sent', 'staking')).toBe('Must not stake');
   });
 
+  test('uses PoX action wording for pox post-conditions', () => {
+    expect(getPostConditionCellText('not_performed', 'pox')).toBe('Must not perform PoX action');
+    expect(getPostConditionCellText('maybe_performed', 'pox')).toBe('May perform PoX action');
+    expect(getPostConditionCellText('performed', 'pox')).toBe('Must perform PoX action');
+  });
+
   test('falls back for unknown condition codes', () => {
     expect(getPostConditionCellText('bogus' as any, 'stx')).toBe('Undefined post condition code');
+    expect(getPostConditionCellText('bogus' as any, 'pox')).toBe('Undefined post condition code');
   });
 });

--- a/src/app/txid/[txId]/redesign/post-conditions/post-condition-table-utils.ts
+++ b/src/app/txid/[txId]/redesign/post-conditions/post-condition-table-utils.ts
@@ -17,9 +17,6 @@ export interface StakingPostCondition {
 
 export type PoxPostConditionConditionCode = 'not_performed' | 'maybe_performed' | 'performed';
 
-// pox-5 also adds a `pox` post-condition covering PoX actions that don't change
-// locking status (unstake, update-bond-registration, ...). It carries neither an
-// asset nor an amount, only whether the action may happen.
 export interface PoxPostCondition {
   type: 'pox';
   principal: PostConditionPrincipal;

--- a/src/app/txid/[txId]/redesign/post-conditions/post-condition-table-utils.ts
+++ b/src/app/txid/[txId]/redesign/post-conditions/post-condition-table-utils.ts
@@ -15,7 +15,18 @@ export interface StakingPostCondition {
   amount: string;
 }
 
-export type PostConditionWithStaking = PostCondition | StakingPostCondition;
+export type PoxPostConditionConditionCode = 'not_performed' | 'maybe_performed' | 'performed';
+
+// pox-5 also adds a `pox` post-condition covering PoX actions that don't change
+// locking status (unstake, update-bond-registration, ...). It carries neither an
+// asset nor an amount, only whether the action may happen.
+export interface PoxPostCondition {
+  type: 'pox';
+  principal: PostConditionPrincipal;
+  condition_code: PoxPostConditionConditionCode;
+}
+
+export type ExtendedPostCondition = PostCondition | StakingPostCondition | PoxPostCondition;
 
 type PostConditionNonFungibleConditionCode = Extract<
   Transaction['post_conditions'][number],
@@ -24,9 +35,10 @@ type PostConditionNonFungibleConditionCode = Extract<
 
 export type PostConditionConditionCode =
   | PostConditionFungibleConditionCode
-  | PostConditionNonFungibleConditionCode;
+  | PostConditionNonFungibleConditionCode
+  | PoxPostConditionConditionCode;
 
-export function getAmount(postCondition: PostConditionWithStaking): string {
+export function getAmount(postCondition: ExtendedPostCondition): string {
   if (postCondition.type === 'stx') {
     return postCondition.amount || '';
   }
@@ -43,10 +55,27 @@ export function getAmount(postCondition: PostConditionWithStaking): string {
   return '';
 }
 
+function getPoxPostConditionCellText(postConditionCode: PostConditionConditionCode): string {
+  if (postConditionCode === 'not_performed') {
+    return 'Must not perform PoX action';
+  }
+  if (postConditionCode === 'maybe_performed') {
+    return 'May perform PoX action';
+  }
+  if (postConditionCode === 'performed') {
+    return 'Must perform PoX action';
+  }
+  return 'Undefined post condition code';
+}
+
 export function getPostConditionCellText(
   postConditionCode: PostConditionConditionCode,
-  postConditionType: PostConditionWithStaking['type']
+  postConditionType: ExtendedPostCondition['type']
 ): string {
+  if (postConditionType === 'pox') {
+    return getPoxPostConditionCellText(postConditionCode);
+  }
+
   const verb = postConditionType === 'staking' ? 'stake' : 'transfer';
   const verbThirdPerson = postConditionType === 'staking' ? 'Stakes' : 'Transfers';
   if (postConditionCode === 'sent_equal_to') {

--- a/src/common/components/Select.tsx
+++ b/src/common/components/Select.tsx
@@ -31,9 +31,6 @@ export function Select<V extends string, L extends string>({
   defaultValue?: V[];
   placeholder?: string;
   selectProps?: SelectRootProps<V, L>;
-  // Accessible name for the control. The underlying select always emits
-  // aria-labelledby pointing at its label, so without one that reference dangles
-  // and the trigger announces only its current value.
   label?: string;
 } & SelectVariantProps) {
   const positioning = selectProps?.positioning;

--- a/src/common/components/Select.tsx
+++ b/src/common/components/Select.tsx
@@ -3,12 +3,18 @@ import {
   SelectControl,
   SelectHiddenSelect,
   SelectItem,
+  SelectLabel,
   SelectRoot,
   SelectRootProps,
   SelectTrigger,
   SelectVariantProps,
 } from '@/components/ui/select';
-import { SelectValueChangeDetails, Stack, createListCollection } from '@chakra-ui/react';
+import {
+  SelectValueChangeDetails,
+  Stack,
+  VisuallyHidden,
+  createListCollection,
+} from '@chakra-ui/react';
 import { useEffect, useRef, useState } from 'react';
 
 export function Select<V extends string, L extends string>({
@@ -18,12 +24,17 @@ export function Select<V extends string, L extends string>({
   onValueChange,
   selectProps,
   size,
+  label,
 }: {
   items: { value: V; label: L }[];
   onValueChange?: (details: SelectValueChangeDetails<{ value: V; label: L }>) => void;
   defaultValue?: V[];
   placeholder?: string;
   selectProps?: SelectRootProps<V, L>;
+  // Accessible name for the control. The underlying select always emits
+  // aria-labelledby pointing at its label, so without one that reference dangles
+  // and the trigger announces only its current value.
+  label?: string;
 } & SelectVariantProps) {
   const positioning = selectProps?.positioning;
   const list = createListCollection<{ value: V; label: L }>({
@@ -68,6 +79,11 @@ export function Select<V extends string, L extends string>({
       size={size}
       {...selectProps}
     >
+      {label ? (
+        <VisuallyHidden asChild>
+          <SelectLabel>{label}</SelectLabel>
+        </VisuallyHidden>
+      ) : null}
       <SelectHiddenSelect />
       <SelectControl
         ref={controlRef}

--- a/src/common/components/Select.tsx
+++ b/src/common/components/Select.tsx
@@ -1,7 +1,6 @@
 import {
   SelectContent,
   SelectControl,
-  SelectHiddenSelect,
   SelectItem,
   SelectLabel,
   SelectRoot,
@@ -81,7 +80,6 @@ export function Select<V extends string, L extends string>({
           <SelectLabel>{label}</SelectLabel>
         </VisuallyHidden>
       ) : null}
-      <SelectHiddenSelect />
       <SelectControl
         ref={controlRef}
         open={open}

--- a/src/common/utils/__tests__/post-condition-mode-utils.test.ts
+++ b/src/common/utils/__tests__/post-condition-mode-utils.test.ts
@@ -1,0 +1,24 @@
+import { PostConditionMode } from '@stacks/transactions';
+
+import { postConditionModeFromName, postConditionModeNames } from '../post-condition-mode-utils';
+
+describe('post condition mode names', () => {
+  test('round-trips every mode, including originator', () => {
+    Object.values(PostConditionMode)
+      .filter((mode): mode is PostConditionMode => typeof mode === 'number')
+      .forEach(mode => {
+        expect(postConditionModeFromName(postConditionModeNames[mode])).toBe(mode);
+      });
+  });
+
+  test('returns undefined for a name that is not a mode', () => {
+    expect(postConditionModeFromName('bogus')).toBeUndefined();
+    expect(postConditionModeFromName(undefined)).toBeUndefined();
+  });
+
+  test('does not resolve inherited object members', () => {
+    expect(postConditionModeFromName('constructor')).toBeUndefined();
+    expect(postConditionModeFromName('toString')).toBeUndefined();
+    expect(postConditionModeFromName('__proto__')).toBeUndefined();
+  });
+});

--- a/src/common/utils/post-condition-mode-utils.ts
+++ b/src/common/utils/post-condition-mode-utils.ts
@@ -1,0 +1,40 @@
+import { PostConditionMode, PostConditionModeName } from '@stacks/transactions';
+
+export const postConditionModeNames: Record<PostConditionMode, PostConditionModeName> = {
+  [PostConditionMode.Allow]: 'allow',
+  [PostConditionMode.Originator]: 'originator',
+  [PostConditionMode.Deny]: 'deny',
+};
+
+// Spelled out rather than derived, so the modes stay numbers: reversing a record
+// keyed by a numeric enum yields string values, and a string mode silently fails
+// every `=== PostConditionMode.X` comparison downstream.
+const postConditionModeByName: Record<PostConditionModeName, PostConditionMode> = {
+  allow: PostConditionMode.Allow,
+  originator: PostConditionMode.Originator,
+  deny: PostConditionMode.Deny,
+};
+
+export function postConditionModeFromName(name: string | undefined): PostConditionMode | undefined {
+  // hasOwn, not a bare index: a bare lookup returns inherited members for keys
+  // like 'constructor', which are non-null and so slip past callers' null checks
+  return name != null && Object.hasOwn(postConditionModeByName, name)
+    ? postConditionModeByName[name as PostConditionModeName]
+    : undefined;
+}
+
+// Ordered least to most restrictive, so the modes read as a spectrum in the picker
+export const postConditionModeOptions: { value: PostConditionModeName; label: string }[] = [
+  { value: 'allow', label: 'Allow mode' },
+  { value: 'originator', label: 'Originator mode' },
+  { value: 'deny', label: 'Deny mode' },
+];
+
+export const postConditionModeDescriptions: Record<PostConditionMode, string> = {
+  [PostConditionMode.Allow]:
+    'The post-conditions listed below are still enforced, but transfers they do not cover are permitted too. It is the least restrictive mode.',
+  [PostConditionMode.Originator]:
+    'Originator mode requires every asset transfer out of your account to be covered by a post-condition listed below. Transfers between other accounts, such as contracts, are unrestricted.',
+  [PostConditionMode.Deny]:
+    'Deny mode only permits the asset transfers explicitly listed in the post-conditions below. Any transfer that is not listed will cause the transaction to fail.',
+};

--- a/src/common/utils/post-condition-mode-utils.ts
+++ b/src/common/utils/post-condition-mode-utils.ts
@@ -6,9 +6,6 @@ export const postConditionModeNames: Record<PostConditionMode, PostConditionMode
   [PostConditionMode.Deny]: 'deny',
 };
 
-// Spelled out rather than derived, so the modes stay numbers: reversing a record
-// keyed by a numeric enum yields string values, and a string mode silently fails
-// every `=== PostConditionMode.X` comparison downstream.
 const postConditionModeByName: Record<PostConditionModeName, PostConditionMode> = {
   allow: PostConditionMode.Allow,
   originator: PostConditionMode.Originator,
@@ -16,14 +13,11 @@ const postConditionModeByName: Record<PostConditionModeName, PostConditionMode> 
 };
 
 export function postConditionModeFromName(name: string | undefined): PostConditionMode | undefined {
-  // hasOwn, not a bare index: a bare lookup returns inherited members for keys
-  // like 'constructor', which are non-null and so slip past callers' null checks
   return name != null && Object.hasOwn(postConditionModeByName, name)
     ? postConditionModeByName[name as PostConditionModeName]
     : undefined;
 }
 
-// Ordered least to most restrictive, so the modes read as a spectrum in the picker
 export const postConditionModeOptions: { value: PostConditionModeName; label: string }[] = [
   { value: 'allow', label: 'Allow mode' },
   { value: 'originator', label: 'Originator mode' },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
support pox-5 post-conditions and originator mode

## Issue ticket number and link
closes #2804
closes #2806
closes #2814

# Checklist:
- [x] I have performed a self-review of my code.
- [ ] I have tested the change on desktop and mobile.
- [x] I have added thorough tests where applicable.
- [x] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):

## Marketing Summary
PoX-5 transactions now read correctly in the Explorer. Staking and PoX post-conditions are spelled out in plain language on the transaction page, so you can see at a glance whether a transaction is allowed to stake, unstake, or touch your PoX state — where previously some of them showed as "Undefined post condition code".

The sandbox keeps up too: you can now build staking and PoX post-conditions when calling a contract, and choose Originator mode alongside Allow and Deny. Originator mode protects every asset leaving your own account while leaving contract-to-contract transfers unrestricted, which is what most DeFi calls actually want.
