### PR TITLE
fix: attach the Stacks API key only to the configured API servers

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ To install project dependencies:
 
 ## Setting Environment Variables
 
-The Explorer application needs the environment variables listed below to work properly. 
+The Explorer application needs the environment variables listed below to work properly.
 
 ```
 NEXT_PUBLIC_MAINNET_API_SERVER=https://api.hiro.so
@@ -38,6 +38,11 @@ NEXT_PUBLIC_DEPLOYMENT_URL=https://explorer.hiro.so
 NEXT_PUBLIC_MAINNET_ENABLED="true"
 NEXT_PUBLIC_DEFAULT_POLLING_INTERVAL="10000"
 ```
+
+`EXPLORER_STACKS_API_KEY` (optional, server-side only) authenticates the server's requests to the
+Stacks API. It is sent only to the servers named by `NEXT_PUBLIC_MAINNET_API_SERVER` and
+`NEXT_PUBLIC_TESTNET_API_SERVER`; a custom `api` host chosen by a visitor never receives it, and the
+transaction page does not fetch from such a host during server-side rendering at all.
 
 > **_NOTE:_**
 >

--- a/docs/workplans/2831-scope-api-key-to-configured-servers.md
+++ b/docs/workplans/2831-scope-api-key-to-configured-servers.md
@@ -1,0 +1,63 @@
+# 2831 — Scope the server-side Stacks API key to the configured API servers
+
+**Task ID:** 2831 — https://github.com/stx-labs/explorer/issues/2831
+**Status:** Completed
+
+## Problem Statement
+
+`src/api/stacksAPIFetch.ts` set `x-api-key` from `EXPLORER_STACKS_API_KEY` on every server-side
+request, and server components build their API URL from the visitor-supplied `api` query parameter
+(`getApiUrl(chain, api)`). A request such as `/txid/<id>?api=https://host.example` therefore made the
+explorer's server call that host with the key attached. Found by the independent reviews of #2830;
+split out so the change is reviewed on its own.
+
+## Components Involved
+
+- `src/api/stacksAPIFetch.ts` — attaches the key only when `isConfiguredApiUrl(url)`
+- `src/common/utils/network-utils.ts` — `isConfiguredApiUrl`, `canServerFetch`
+- `src/app/txid/[txId]/page.tsx` — no server-side fetch when `api` names a non-configured host
+  (client render, as `ssr=false` already does)
+- `src/api/__tests__/stacksAPIFetch.test.ts`, `src/common/utils/__tests__/network-utils-origins.test.ts`
+- `docs/getting-started.md` — documents `EXPLORER_STACKS_API_KEY`
+
+## Dependencies
+
+None. #2830 carries the same change; it drops out of that diff once this merges.
+
+## Implementation Checklist
+
+- [x] Key attached only to URLs whose origin and path prefix match `NEXT_PUBLIC_MAINNET_API_SERVER`
+      or `NEXT_PUBLIC_TESTNET_API_SERVER` — the same constants the fetchers build URLs from
+- [x] Transaction page skips SSR fetching for any other `api` host
+- [x] Tests: key sent to both configured servers (trailing slash, path prefix); never to other hosts,
+      including a look-alike domain and a link-local address; `canServerFetch` false for custom hosts
+- [x] `docs/getting-started.md` documents the variable and where it is sent
+
+## Verification Steps
+
+1. `pnpm lint`, `pnpm test:unit`, `pnpm build` green.
+2. Locally, with a request-logging server as `?api=`: the transaction page no longer contacts it;
+   mainnet and testnet pages behave as before.
+3. After deploy: no rise in upstream `429`s in the function logs — a wrong match would strip the key
+   from every server request and push the site onto the public rate limit.
+
+## Decision Authority
+
+- Scope (wrapper plus the transaction page only): Alex.
+
+## Questions/Uncertainties
+
+**Blocking:** none.
+
+**Non-blocking:** whether to gate the remaining server components (`blocks`, `address`, `mempool`,
+`transactions`, `stx`, `token`, home) the same way. They still fetch a custom `api` host during SSR,
+now without the key.
+
+## Acceptable Tradeoffs
+
+- Custom-network visitors get a client-rendered transaction page, identical to `ssr=false`.
+
+## Notes
+
+- The first draft compared whole URLs and never attached the key. The tests derive the expected URLs
+  from the same env constants as production, so that cannot recur unnoticed.

--- a/src/api/__tests__/stacksAPIFetch.test.ts
+++ b/src/api/__tests__/stacksAPIFetch.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment node
+ */
+import { getApiUrl } from '@/common/utils/network-utils';
+
+import { stacksAPIFetch } from '../stacksAPIFetch';
+
+describe('stacksAPIFetch', () => {
+  const realFetch = global.fetch;
+  let calls: { url: string; headers: Headers }[] = [];
+
+  beforeEach(() => {
+    calls = [];
+    process.env.EXPLORER_STACKS_API_KEY = 'test-key';
+    global.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), headers: new Headers(init?.headers) });
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    delete process.env.EXPLORER_STACKS_API_KEY;
+  });
+
+  it('sends the API key to the configured public servers', async () => {
+    await stacksAPIFetch(`${getApiUrl('mainnet')}/extended/v1/tx/0xabc`);
+    await stacksAPIFetch(`${getApiUrl('testnet')}/extended/v1/tx/0xabc`);
+    expect(calls.map(c => c.headers.get('x-api-key'))).toEqual(['test-key', 'test-key']);
+  });
+
+  it('never sends the API key to any other host', async () => {
+    for (const url of [
+      'https://evil.example/extended/v1/tx/0xabc',
+      'http://127.0.0.1:4010/extended/v1/tx/0xabc',
+      'http://169.254.169.254/latest/meta-data',
+      'https://api.hiro.so.evil.example/extended/v1/tx/0xabc',
+    ]) {
+      calls = [];
+      await stacksAPIFetch(url);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].headers.get('x-api-key')).toBeNull();
+    }
+  });
+});

--- a/src/api/stacksAPIFetch.ts
+++ b/src/api/stacksAPIFetch.ts
@@ -1,7 +1,13 @@
+import { isConfiguredApiUrl } from '@/common/utils/network-utils';
+
 export async function stacksAPIFetch(url: string, options: RequestInit = {}) {
   const reqHeaders = new Headers(options.headers || {});
 
-  reqHeaders.set('x-api-key', process.env.EXPLORER_STACKS_API_KEY || '');
+  // The explorer's key belongs to the configured public API servers only. Several server
+  // components derive the URL from a visitor-supplied `api` parameter; that host must never see it.
+  if (isConfiguredApiUrl(url)) {
+    reqHeaders.set('x-api-key', process.env.EXPLORER_STACKS_API_KEY || '');
+  }
 
   try {
     const { headers: getHeaders } = await import('next/headers');

--- a/src/app/txid/[txId]/page.tsx
+++ b/src/app/txid/[txId]/page.tsx
@@ -3,7 +3,7 @@ import { getTokenPrice } from '@/app/getTokenPriceInfo';
 import { CommonSearchParams } from '@/app/transactions/page';
 import { NetworkModes } from '@/common/types/network';
 import { logError } from '@/common/utils/error-utils';
-import { getApiUrl } from '@/common/utils/network-utils';
+import { canServerFetch, getApiUrl } from '@/common/utils/network-utils';
 import { validateStacksContractId } from '@/common/utils/utils';
 
 import {
@@ -51,7 +51,8 @@ export default async function Page(props: {
   let numFunctions: number | undefined;
 
   const isContractId = validateStacksContractId(txId);
-  const isSSRDisabled = ssr === 'false';
+  // A custom `api` host comes from the visitor: never fetched from the server, rendered client-side.
+  const isSSRDisabled = ssr === 'false' || !canServerFetch(apiUrl);
 
   if (!isSSRDisabled) {
     try {

--- a/src/common/utils/__tests__/network-utils-origins.test.ts
+++ b/src/common/utils/__tests__/network-utils-origins.test.ts
@@ -1,0 +1,22 @@
+import { canServerFetch, getApiUrl, isConfiguredApiUrl } from '../network-utils';
+
+describe('configured API origins', () => {
+  it('recognises only the configured public servers', () => {
+    expect(isConfiguredApiUrl(getApiUrl('mainnet'))).toBe(true);
+    expect(isConfiguredApiUrl(`${getApiUrl('mainnet')}/`)).toBe(true);
+    expect(isConfiguredApiUrl(`${getApiUrl('mainnet')}/extended/v1/tx/0xabc`)).toBe(true);
+    expect(isConfiguredApiUrl(getApiUrl('testnet'))).toBe(true);
+    expect(isConfiguredApiUrl('https://evil.example')).toBe(false);
+    expect(isConfiguredApiUrl('http://169.254.169.254/latest')).toBe(false);
+    expect(isConfiguredApiUrl('https://api.hiro.so.evil.example')).toBe(false);
+    expect(isConfiguredApiUrl('not a url')).toBe(false);
+    expect(isConfiguredApiUrl(undefined)).toBe(false);
+  });
+
+  it('lets the server fetch only from those servers', () => {
+    expect(canServerFetch(getApiUrl('mainnet'))).toBe(true);
+    expect(canServerFetch(getApiUrl('testnet'))).toBe(true);
+    expect(canServerFetch(getApiUrl('mainnet', 'http://localhost:3999'))).toBe(false);
+    expect(canServerFetch(getApiUrl('mainnet', 'https://my-node.example/api'))).toBe(false);
+  });
+});

--- a/src/common/utils/network-utils.ts
+++ b/src/common/utils/network-utils.ts
@@ -23,6 +23,38 @@ export function getApiUrl(chain: string, customApiUrl?: string): string {
   return DEFAULT_MAINNET_SERVER;
 }
 
+/**
+ * Whether `url` is one of the configured public API servers. Server-side code must only attach
+ * `EXPLORER_STACKS_API_KEY` to, and only fetch on a visitor's behalf from, these servers: a custom
+ * `api` parameter is visitor-controlled and could name any host.
+ */
+export function isConfiguredApiUrl(url: string | undefined | null): boolean {
+  if (!url) return false;
+  let target: URL;
+  try {
+    target = new URL(url);
+  } catch {
+    return false;
+  }
+  return [DEFAULT_MAINNET_SERVER, DEFAULT_TESTNET_SERVER].some(configured => {
+    try {
+      const c = new URL(configured);
+      const base = c.pathname.replace(/\/$/, '');
+      return (
+        target.origin === c.origin &&
+        (base === '' || target.pathname === base || target.pathname.startsWith(`${base}/`))
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+
+/** Whether a server component may fetch from `apiUrl` during render (custom networks stay client-side). */
+export function canServerFetch(apiUrl: string | undefined | null): boolean {
+  return isConfiguredApiUrl(apiUrl);
+}
+
 export function isHiroSubdomain(url: string): boolean {
   try {
     const parsedUrl = new URL(url);


### PR DESCRIPTION
PR from Claude (filed by @stacks-alex):

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`src/api/stacksAPIFetch.ts` set `x-api-key` from `EXPLORER_STACKS_API_KEY` on every server-side request, and server components build their API URL from the visitor-supplied `api` query parameter through `getApiUrl(chain, api)`. A request such as `/txid/<id>?api=https://host.example` therefore made the explorer's server call that host with the key attached.

This PR:

- attaches the key only to requests whose origin and path prefix match `NEXT_PUBLIC_MAINNET_API_SERVER` or `NEXT_PUBLIC_TESTNET_API_SERVER` (`isConfiguredApiUrl` in `network-utils.ts`). These are the same constants the fetchers build their URLs from, so a configuration change cannot desynchronise the check;
- makes the transaction page skip server-side fetching when `api` names any other host; it renders client-side, exactly as `ssr=false` already does (`canServerFetch`);
- documents `EXPLORER_STACKS_API_KEY` in `docs/getting-started.md`.

**Design decisions and trade-offs**

- Deliberately minimal. The wrapper is the actual leak; gating the transaction page removes the SSR path the reviews exercised. The other server components (`blocks`, `address`, `mempool`, `transactions`, `stx`, `token`, home) still fetch a custom `api` host during SSR, now without the key; gating them the same way is a candidate follow-up.
- Custom networks never needed Hiro's key, so they lose nothing. A custom-network visitor gets a client-rendered transaction page.
- The failure mode to watch is a wrong match, which would strip the key from every server request and push production onto the public rate limit. The tests derive the expected URLs from the same env constants (trailing slash and path prefix covered) and assert the key is never sent to four other hosts, including a look-alike domain and a link-local address. After deploy, upstream `429`s in the function logs are the signal that something is off.

Found during the independent reviews of #2830, which currently carries the same change; it drops out of that diff once this merges.

**To reproduce**

Run a request-logging server locally (anything that prints request headers) and open `/txid/<any txid>?api=http://127.0.0.1:<port>` with `EXPLORER_STACKS_API_KEY` set. Before this change the explorer's server calls that host with `x-api-key`; after it, the host is not contacted at all and the page renders client-side. Or run the two new test files.

## Issue ticket number and link

Closes #2831

# Checklist:
- [x] I have performed a self-review of my code.
- [ ] I have tested the change on desktop and mobile. (no UI change; verified with unit tests and a local request-logging host)
- [x] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable. (not applicable)

**Testing:** `pnpm lint`, `pnpm test:unit` and `pnpm build` pass locally.

## Screenshots (if appropriate):

Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
