### PR TITLE
fix(staking): hover card that stays out of the way, calmer lifecycle, unpinned tables

### DIFF
--- a/src/app/staking/BondTooltip.tsx
+++ b/src/app/staking/BondTooltip.tsx
@@ -34,6 +34,17 @@ const STATE_BADGES: Record<BondLifecycleState, { bg: string; color: string }> = 
 
 const ENROLLING_ACCENT = 'accent.bitcoin-500';
 
+export const hasBondActions = (state: BondLifecycleState) =>
+  state === 'scheduled' || state === 'enrolling';
+
+export function bondSummary(bond: BondTooltipData, currentBurnHeight: number, nowMs: number) {
+  const date = (height: number) =>
+    `${height > currentBurnHeight ? '~' : ''}${formatDateShort(
+      burnHeightToApproximateTimestamp(height, currentBurnHeight, nowMs)
+    )}`;
+  return `${bond.label} · ${STATE_LABELS[bond.state]} · ${date(bond.schedule.activationHeight)} → ${date(bond.schedule.termEndHeight)}`;
+}
+
 export interface BondTooltipData {
   label: string;
   state: BondLifecycleState;
@@ -191,8 +202,8 @@ export function BondTooltip({
         </Text>
       )}
 
-      {(state === 'scheduled' || state === 'enrolling') && (
-        <Flex gap={4} pt={2} borderTop="1px solid" borderColor="neutral.sand-500" flexWrap="wrap">
+      {hasBondActions(state) && (
+        <Flex gap={4} pt={1} flexWrap="wrap">
           <TooltipAction href={STAKING_LINKS.estimateYield} arrow="out">
             Estimate your yield
           </TooltipAction>

--- a/src/app/staking/BondsTable.tsx
+++ b/src/app/staking/BondsTable.tsx
@@ -132,7 +132,6 @@ const bondColumns: ColumnDef<BondRow>[] = [
     accessorKey: 'name',
     enableSorting: false,
     size: 110,
-    meta: { isPinned: 'left' },
     cell: info => (
       <Text textStyle="text-medium-sm" whiteSpace="nowrap">
         {info.getValue() as string}

--- a/src/app/staking/CurrentBond.tsx
+++ b/src/app/staking/CurrentBond.tsx
@@ -27,6 +27,8 @@ import { bondLabel, formatBtc, formatDateWithYear, toBigInt } from './utils';
 
 const BAR_HEIGHT = 2;
 
+const PULSE_MS = 2400;
+
 const STATE_LABELS: Record<BondLifecycleState, string> = {
   scheduled: 'Scheduled',
   enrolling: 'Enrolling',
@@ -87,34 +89,52 @@ interface Milestone {
   isCurrent?: boolean;
 }
 
-function LifecycleRow({ milestone }: { milestone: Milestone }) {
+function LifecycleRow({ milestone, live }: { milestone: Milestone; live: boolean }) {
   const { label, height, timestamp, isPast, isCurrent } = milestone;
+  const reached = isPast || isCurrent;
   return (
     <Flex justify="space-between" gap={3} align="center" flexWrap="wrap">
       <Flex gap={3} align="center" minW="12rem">
         <Box
+          position="relative"
+          isolation="isolate"
           w={2}
           h={2}
           borderRadius="full"
           flexShrink={0}
           bg={isCurrent ? 'accent.stacks-500' : isPast ? 'feedback.green-500' : 'transparent'}
-          border={isPast || isCurrent ? undefined : '1px solid'}
+          border={reached ? undefined : '1px solid'}
           borderColor="redesignBorderSecondary"
+          _before={
+            isCurrent && live
+              ? {
+                  content: '""',
+                  position: 'absolute',
+                  inset: 0,
+                  zIndex: -1,
+                  borderRadius: 'full',
+                  bg: 'accent.stacks-500',
+                  opacity: 0.45,
+                  animation: `lifecycle-pulse ${PULSE_MS}ms cubic-bezier(0, 0, 0.2, 1) infinite`,
+                }
+              : undefined
+          }
+          _motionReduce={{ _before: { animation: 'none' } }}
         />
-        <Text textStyle={isPast || isCurrent ? 'text-medium-sm' : 'text-regular-sm'}>{label}</Text>
+        <Text textStyle={reached ? 'text-medium-sm' : 'text-regular-sm'}>{label}</Text>
       </Flex>
       <Flex gap={6} align="baseline">
-        <Text textStyle="text-mono-xs" color={isPast ? 'accent.stacks-500' : 'textSecondary'}>
+        <Text textStyle="text-mono-xs" color={reached ? 'accent.stacks-500' : 'textSecondary'}>
           #{height.toLocaleString()}
         </Text>
         <Text
           textStyle="text-regular-sm"
-          color={isPast ? 'textPrimary' : 'accent.stacks-500'}
+          color={reached ? 'textPrimary' : 'textSecondary'}
           minW="7rem"
           textAlign="right"
           suppressHydrationWarning
         >
-          {isPast ? formatDateShort(timestamp) : `~${formatDateShort(timestamp)}`}
+          {reached ? formatDateShort(timestamp) : `~${formatDateShort(timestamp)}`}
         </Text>
       </Flex>
     </Flex>
@@ -307,7 +327,7 @@ export function CurrentBond({
                 borderTop={index > 0 ? '1px solid' : undefined}
                 borderColor="redesignBorderSecondary"
               >
-                <LifecycleRow milestone={milestone} />
+                <LifecycleRow milestone={milestone} live={state === 'active'} />
               </Box>
             ))}
           </Stack>

--- a/src/app/staking/PeriodsOverview.tsx
+++ b/src/app/staking/PeriodsOverview.tsx
@@ -346,10 +346,6 @@ export function PeriodsOverview({
             {statesShown.has('upcoming') && (
               <LegendKey swatch={<Swatch dashed />} label="Scheduled · not yet started" />
             )}
-            <LegendKey
-              swatch={<Box w={4} borderTop="1px dashed" borderColor="neutral.sand-400" />}
-              label="Today"
-            />
           </Flex>
         </Stack>
       )}

--- a/src/app/staking/TimelinePlot.tsx
+++ b/src/app/staking/TimelinePlot.tsx
@@ -4,10 +4,13 @@ import { ChartTooltipSurface } from '@/common/components/ChartTooltipSurface';
 import { Text } from '@/ui/Text';
 import { Box, Flex, Stack } from '@chakra-ui/react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
-import { BondTooltip } from './BondTooltip';
+import { BondTooltip, bondSummary, hasBondActions } from './BondTooltip';
 import type { BondTooltipData } from './BondTooltip';
 import { DISTRIBUTIONS_PER_BOND } from './consts';
+import { isInsideApproach, placeHoverCard, preferredSide } from './hoverCard';
+import type { HoverCardAnchor, HoverCardView } from './hoverCard';
 import type { BondTimelineState, DistributionGridCell } from './projections';
 import { approximateBurnHeightAt, burnHeightToRewardCycle } from './projections';
 import { formatDateWithYear } from './utils';
@@ -19,11 +22,13 @@ const PLOT_TOP = 9;
 
 const FOLLOW_MS = 150;
 
-const BAR_GRACE_MS = 200;
+const BAR_HOLD_MS = 150;
 
-const POINTER_OFFSET = 14;
+const REST_MS = 220;
 
-const REST_TOP = 4;
+const REST_TOLERANCE = 4;
+
+const VIEW_MARGIN = 8;
 
 export const SEGMENT_PAID_BG = 'accent.stacks-500';
 export const SEGMENT_REMAINING_BG = 'accent.stacks-300';
@@ -70,29 +75,69 @@ export interface TimelineRow {
 
 export type PlotRow = TimelineRow & { tooltip: BondTooltipData };
 
+interface PlotOrigin {
+  x: number;
+  y: number;
+}
+
 interface PlotPointer {
   x: number;
   y: number;
   plotWidth: number;
   plotHeight: number;
+  view: HoverCardView;
+  origin: PlotOrigin;
+}
+
+function describePlot(rect: DOMRect) {
+  return {
+    plotWidth: rect.width,
+    plotHeight: rect.height,
+    view: {
+      width: rect.width,
+      top: VIEW_MARGIN - rect.top,
+      bottom: window.innerHeight - rect.top - VIEW_MARGIN,
+    },
+    origin: { x: rect.left + window.scrollX, y: rect.top + window.scrollY },
+  };
+}
+
+interface HoverState {
+  pointer: PlotPointer;
+  anchor: HoverCardAnchor;
+  bondIndex?: number;
+  held: boolean;
+  expanded: boolean;
 }
 
 function HoverCard({
-  pointer,
-  restPercent,
+  anchor,
+  view,
+  origin,
   plotWidth,
+  interactive,
+  restPercent,
+  restCenter,
   rich,
+  cardRef,
   children,
 }: {
-  pointer?: PlotPointer;
-  restPercent: number;
+  anchor?: HoverCardAnchor;
+  view?: HoverCardView;
+  origin?: PlotOrigin;
   plotWidth?: number;
+  interactive: boolean;
+  restPercent: number;
+  restCenter: number;
   rich: boolean;
+  cardRef: React.RefObject<HTMLDivElement | null>;
   children: React.ReactNode;
 }) {
   const contentRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState<{ width: number; height: number }>();
+  const [mounted, setMounted] = useState(false);
 
+  useEffect(() => setMounted(true), []);
   useEffect(() => {
     const element = contentRef.current;
     if (!element) return;
@@ -101,48 +146,51 @@ function HoverCard({
     const observer = new ResizeObserver(measure);
     observer.observe(element);
     return () => observer.disconnect();
-  }, []);
+  }, [mounted]);
+
+  if (!mounted || !origin) return null;
 
   const width = size?.width ?? 0;
   const height = size?.height ?? 0;
+  const { x, y } =
+    anchor && view
+      ? placeHoverCard(anchor, { width, height }, view)
+      : {
+          x: (restPercent / 100) * (plotWidth ?? 0) - width / 2,
+          y: Math.max(restCenter - height / 2, 0),
+        };
 
-  let x: number | undefined;
-  let y = REST_TOP;
-  if (pointer) {
-    x = Math.min(Math.max(pointer.x - width / 2, 0), Math.max(pointer.plotWidth - width, 0));
-    const below = pointer.y + POINTER_OFFSET;
-    y =
-      below + height <= pointer.plotHeight
-        ? below
-        : Math.max(pointer.y - POINTER_OFFSET - height, 0);
-  } else if (plotWidth !== undefined) {
-    x = (restPercent / 100) * plotWidth - width / 2;
-  }
-
-  return (
-    <ChartTooltipSurface
-      bg="var(--stacks-colors-alpha-black-alpha-800)"
+  return createPortal(
+    <Box
+      ref={cardRef}
       position="absolute"
       top={0}
-      left={x === undefined ? `calc(${restPercent}% - ${width / 2}px)` : 0}
-      w={size ? undefined : 'max-content'}
-      overflow="hidden"
-      zIndex={2}
-      pointerEvents={rich ? 'auto' : 'none'}
+      left={0}
+      zIndex="tooltip"
+      pointerEvents={interactive ? 'auto' : 'none'}
       data-hover-card="true"
       willChange="transform"
-      transition={`transform ${FOLLOW_MS}ms ease-out, width ${FOLLOW_MS}ms ease-out, height ${FOLLOW_MS}ms ease-out`}
+      transition={`transform ${FOLLOW_MS}ms ease-out`}
       _motionReduce={{ transition: 'none' }}
-      style={{
-        transform: x === undefined ? undefined : `translate3d(${x}px, ${y}px, 0)`,
-        width: size ? `${size.width}px` : undefined,
-        height: size ? `${size.height}px` : undefined,
-      }}
+      style={{ transform: `translate3d(${origin.x + x}px, ${origin.y + y}px, 0)` }}
     >
-      <Box ref={contentRef} w="max-content" px={rich ? 3 : 2} py={rich ? 2.5 : 1}>
-        {children}
-      </Box>
-    </ChartTooltipSurface>
+      <ChartTooltipSurface
+        bg="var(--stacks-colors-alpha-black-alpha-800)"
+        w={size ? undefined : 'max-content'}
+        overflow="hidden"
+        transition={`width ${FOLLOW_MS}ms ease-out, height ${FOLLOW_MS}ms ease-out`}
+        _motionReduce={{ transition: 'none' }}
+        style={{
+          width: size ? `${size.width}px` : undefined,
+          height: size ? `${size.height}px` : undefined,
+        }}
+      >
+        <Box ref={contentRef} w="max-content" px={rich ? 3 : 2} py={rich ? 2.5 : 1}>
+          {children}
+        </Box>
+      </ChartTooltipSurface>
+    </Box>,
+    document.body
   );
 }
 
@@ -157,8 +205,8 @@ const TimelineRows = memo(function TimelineRows({
 }) {
   return (
     <Stack gap={ROW_GAP} position="relative" zIndex={1}>
-      {rows.map(row => (
-        <Flex key={row.index} align="center">
+      {rows.map((row, rowIndex) => (
+        <Flex key={row.index} data-row-index={rowIndex} align="center">
           <Box w={ROW_LABEL_WIDTH} flexShrink={0} pr={3}>
             <Text textStyle="text-regular-sm" whiteSpace="nowrap">
               {row.label}
@@ -233,90 +281,198 @@ export function TimelinePlot({
   firstBurnchainBlockHeight: number;
 }) {
   const plotRef = useRef<HTMLDivElement>(null);
-  const [pointer, setPointer] = useState<PlotPointer>();
-  const [hoveredBondIndex, setHoveredBondIndex] = useState<number>();
-  const barGrace = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const hoveredRef = useRef<number>(undefined);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [hover, setHover] = useState<HoverState>();
+  const hoverRef = useRef<HoverState>(undefined);
+  const rowBand = useRef<{ rowTop: number; rowBottom: number }>(undefined);
+  const hold = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const rest = useRef<{ timer: ReturnType<typeof setTimeout>; x: number; y: number }>(undefined);
   const frame = useRef<number>(undefined);
   const latestMove = useRef<{ x: number; y: number; target: EventTarget | null }>(null);
-  const trackCursor = useCallback((event: React.MouseEvent) => {
-    latestMove.current = { x: event.clientX, y: event.clientY, target: event.target };
-    if (frame.current !== undefined) return;
-    frame.current = requestAnimationFrame(() => {
-      frame.current = undefined;
-      const move = latestMove.current;
-      const rect = plotRef.current?.getBoundingClientRect();
-      if (!move || !rect || rect.width <= 0) return;
-      const target = move.target as HTMLElement | null;
-      if (target?.closest?.('[data-hover-card]')) {
-        clearTimeout(barGrace.current);
-        return;
-      }
-      const x = move.x - rect.left;
-      if (x < 0 || x > rect.width) {
-        setPointer(undefined);
-        return;
-      }
-      const bar = target?.closest?.('[data-bond-index]') as HTMLElement | null;
-      clearTimeout(barGrace.current);
-      if (bar?.dataset.bondIndex !== undefined) {
-        const index = Number(bar.dataset.bondIndex);
-        if (hoveredRef.current !== index) {
-          hoveredRef.current = index;
-          setHoveredBondIndex(index);
-          setPointer({ x, y: move.y - rect.top, plotWidth: rect.width, plotHeight: rect.height });
-        }
-        return;
-      }
-      setPointer({ x, y: move.y - rect.top, plotWidth: rect.width, plotHeight: rect.height });
-      if (hoveredRef.current !== undefined) {
-        barGrace.current = setTimeout(() => {
-          hoveredRef.current = undefined;
-          setHoveredBondIndex(undefined);
-        }, BAR_GRACE_MS);
-      }
-    });
+  const actionable = useRef(new Set<number>());
+  actionable.current = new Set(
+    rows.filter(row => hasBondActions(row.tooltip.state)).map(row => row.index)
+  );
+
+  const commit = useCallback((next: HoverState | undefined) => {
+    hoverRef.current = next;
+    setHover(next);
   }, []);
+  const releaseHold = useCallback(() => {
+    const latest = hoverRef.current;
+    if (latest?.held) commit({ ...latest, bondIndex: undefined, held: false });
+  }, [commit]);
+  const clearRest = useCallback(() => {
+    if (rest.current) clearTimeout(rest.current.timer);
+    rest.current = undefined;
+  }, []);
+  const expand = useCallback(() => {
+    rest.current = undefined;
+    const latest = hoverRef.current;
+    if (latest && latest.bondIndex !== undefined && !latest.held && !latest.expanded) {
+      commit({ ...latest, expanded: true });
+    }
+  }, [commit]);
+  const armRest = useCallback(
+    (x: number, y: number) => {
+      if (rest.current) clearTimeout(rest.current.timer);
+      rest.current = { timer: setTimeout(expand, REST_MS), x, y };
+    },
+    [expand]
+  );
+
+  const trackCursor = useCallback(
+    (event: React.MouseEvent) => {
+      latestMove.current = { x: event.clientX, y: event.clientY, target: event.target };
+      if (frame.current !== undefined) return;
+      frame.current = requestAnimationFrame(() => {
+        frame.current = undefined;
+        const move = latestMove.current;
+        const rect = plotRef.current?.getBoundingClientRect();
+        if (!move || !rect || rect.width <= 0) return;
+        const target = move.target as HTMLElement | null;
+        const bar = target?.closest?.('[data-bond-index]') as HTMLElement | null;
+        const bondIndex =
+          bar?.dataset.bondIndex === undefined ? undefined : Number(bar.dataset.bondIndex);
+        const current = hoverRef.current;
+        const x = move.x - rect.left;
+        const y = move.y - rect.top;
+        if (current?.expanded) {
+          const interactive =
+            current.bondIndex !== undefined && actionable.current.has(current.bondIndex);
+          const onCard = interactive && target?.closest?.('[data-hover-card]');
+          const cardRect = interactive ? cardRef.current?.getBoundingClientRect() : undefined;
+          const approaching =
+            cardRect &&
+            isInsideApproach(
+              current.anchor,
+              {
+                left: cardRect.left - rect.left,
+                right: cardRect.right - rect.left,
+                top: cardRect.top - rect.top,
+                bottom: cardRect.bottom - rect.top,
+              },
+              { x, y }
+            );
+          if (bondIndex === current.bondIndex || onCard || approaching) return;
+        }
+        if (x < 0 || x > rect.width) {
+          clearTimeout(hold.current);
+          clearRest();
+          rowBand.current = undefined;
+          commit(undefined);
+          return;
+        }
+        const row = target?.closest?.('[data-row-index]');
+        if (row) {
+          const rowRect = row.getBoundingClientRect();
+          rowBand.current = {
+            rowTop: rowRect.top - rect.top,
+            rowBottom: rowRect.bottom - rect.top,
+          };
+        }
+        const band = rowBand.current ?? { rowTop: y, rowBottom: y };
+        let shown = bondIndex;
+        let held = false;
+        if (bondIndex === undefined && current?.bondIndex !== undefined) {
+          shown = current.bondIndex;
+          held = true;
+          if (!current.held) hold.current = setTimeout(releaseHold, BAR_HOLD_MS);
+        } else {
+          clearTimeout(hold.current);
+        }
+        if (bondIndex === undefined) {
+          clearRest();
+        } else if (
+          !rest.current ||
+          bondIndex !== current?.bondIndex ||
+          current?.held ||
+          Math.hypot(x - rest.current.x, y - rest.current.y) > REST_TOLERANCE
+        ) {
+          armRest(x, y);
+        }
+        commit({
+          pointer: { x, y, ...describePlot(rect) },
+          anchor: { x, ...band, side: preferredSide(band, rect.height) },
+          bondIndex: shown,
+          held,
+          expanded: false,
+        });
+      });
+    },
+    [commit, releaseHold, armRest, clearRest]
+  );
   const clearCursor = useCallback(() => {
     if (frame.current !== undefined) cancelAnimationFrame(frame.current);
     frame.current = undefined;
-    clearTimeout(barGrace.current);
-    hoveredRef.current = undefined;
-    setPointer(undefined);
-    setHoveredBondIndex(undefined);
-  }, []);
-  const focusBond = useCallback((index: number, element: HTMLElement) => {
-    const plotRect = plotRef.current?.getBoundingClientRect();
-    if (!plotRect || plotRect.width <= 0) return;
-    const barRect = element.getBoundingClientRect();
-    clearTimeout(barGrace.current);
-    hoveredRef.current = index;
-    setHoveredBondIndex(index);
-    setPointer({
-      x: Math.min(Math.max(barRect.left + barRect.width / 2 - plotRect.left, 0), plotRect.width),
-      y: barRect.top + barRect.height / 2 - plotRect.top,
-      plotWidth: plotRect.width,
-      plotHeight: plotRect.height,
-    });
-  }, []);
+    clearTimeout(hold.current);
+    clearRest();
+    rowBand.current = undefined;
+    commit(undefined);
+  }, [commit, clearRest]);
+  const focusBond = useCallback(
+    (index: number, element: HTMLElement) => {
+      const plotRect = plotRef.current?.getBoundingClientRect();
+      if (!plotRect || plotRect.width <= 0) return;
+      const barRect = element.getBoundingClientRect();
+      const rowRect = element.closest('[data-row-index]')?.getBoundingClientRect() ?? barRect;
+      const x = Math.min(
+        Math.max(barRect.left + barRect.width / 2 - plotRect.left, 0),
+        plotRect.width
+      );
+      const band = { rowTop: rowRect.top - plotRect.top, rowBottom: rowRect.bottom - plotRect.top };
+      clearTimeout(hold.current);
+      clearRest();
+      commit({
+        pointer: {
+          x,
+          y: barRect.top + barRect.height / 2 - plotRect.top,
+          ...describePlot(plotRect),
+        },
+        anchor: { x, ...band, side: preferredSide(band, plotRect.height) },
+        bondIndex: index,
+        held: false,
+        expanded: true,
+      });
+    },
+    [commit, clearRest]
+  );
   useEffect(
     () => () => {
-      clearTimeout(barGrace.current);
+      clearTimeout(hold.current);
+      if (rest.current) clearTimeout(rest.current.timer);
       if (frame.current !== undefined) cancelAnimationFrame(frame.current);
     },
     []
   );
 
   const [plotWidth, setPlotWidth] = useState<number>();
+  const [plotOrigin, setPlotOrigin] = useState<PlotOrigin>();
+  const [restCenter, setRestCenter] = useState((PLOT_TOP * 4) / 2);
+  const measurePlot = useCallback(() => {
+    const element = plotRef.current;
+    if (!element) return;
+    const rect = element.getBoundingClientRect();
+    setPlotWidth(rect.width);
+    const origin = { x: rect.left + window.scrollX, y: rect.top + window.scrollY };
+    setPlotOrigin(previous =>
+      previous && previous.x === origin.x && previous.y === origin.y ? previous : origin
+    );
+    const firstRow = element.parentElement?.parentElement?.querySelector('[data-row-index="0"]');
+    if (firstRow) setRestCenter((firstRow.getBoundingClientRect().top - rect.top) / 2);
+  }, []);
+  useEffect(measurePlot);
   useEffect(() => {
     const element = plotRef.current;
     if (!element) return;
-    const measure = () => setPlotWidth(element.getBoundingClientRect().width);
-    measure();
-    const observer = new ResizeObserver(measure);
+    const observer = new ResizeObserver(measurePlot);
     observer.observe(element);
-    return () => observer.disconnect();
-  }, []);
+    window.addEventListener('resize', measurePlot);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', measurePlot);
+    };
+  }, [measurePlot]);
 
   const todayLabel = new Date(nowMs).toLocaleString('en-US', {
     month: 'short',
@@ -324,6 +480,7 @@ export function TimelinePlot({
     timeZone: 'UTC',
   });
 
+  const pointer = hover?.pointer;
   const pointerPercent = pointer ? (pointer.x / pointer.plotWidth) * 100 : undefined;
   const pointerLabel = (() => {
     if (pointerPercent === undefined) return undefined;
@@ -341,7 +498,9 @@ export function TimelinePlot({
       .filter(Boolean)
       .join(' · ');
   })();
-  const hoveredRow = rows.find(row => row.index === hoveredBondIndex);
+  const hoveredRow = rows.find(row => row.index === hover?.bondIndex);
+  const expanded = !!hover?.expanded && hoveredRow !== undefined;
+  const interactive = expanded && hasBondActions(hoveredRow.tooltip.state);
   const hoveredCell =
     pointerPercent === undefined
       ? undefined
@@ -358,13 +517,14 @@ export function TimelinePlot({
       onMouseMove={trackCursor}
       onMouseLeave={clearCursor}
       onBlurCapture={event => {
-        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) clearCursor();
+        const next = event.relatedTarget as Node | null;
+        if (!event.currentTarget.contains(next) && !cardRef.current?.contains(next)) clearCursor();
       }}
     >
       <TimelineRows rows={rows} cells={cells} onBondFocus={focusBond} />
       <Flex position="absolute" inset={0} pointerEvents="none">
         <Box w={ROW_LABEL_WIDTH} flexShrink={0} pr={3} />
-        <Box position="relative" flex={1} ref={plotRef}>
+        <Box position="relative" flex={1} ref={plotRef} data-timeline-plot="true">
           {hoveredCell &&
             rows.map((row, rowIndex) => (
               <Box
@@ -406,12 +566,17 @@ export function TimelinePlot({
             }
           />
           <HoverCard
-            pointer={pointer}
-            restPercent={todayPercent}
+            anchor={hover?.anchor}
+            view={pointer?.view}
+            origin={pointer?.origin ?? plotOrigin}
             plotWidth={plotWidth}
-            rich={!!hoveredRow}
+            interactive={interactive}
+            restPercent={todayPercent}
+            restCenter={restCenter}
+            rich={expanded}
+            cardRef={cardRef}
           >
-            {hoveredRow ? (
+            {expanded ? (
               <BondTooltip
                 bond={hoveredRow.tooltip}
                 distributionsPaid={hoveredRow.distributionsPaid}
@@ -426,7 +591,9 @@ export function TimelinePlot({
                 whiteSpace="nowrap"
                 suppressHydrationWarning
               >
-                {pointerLabel ?? `today · ${todayLabel}`}
+                {hoveredRow
+                  ? bondSummary(hoveredRow.tooltip, currentBurnHeight, nowMs)
+                  : (pointerLabel ?? `today · ${todayLabel}`)}
               </Text>
             )}
           </HoverCard>

--- a/src/app/staking/TimelinePlot.tsx
+++ b/src/app/staking/TimelinePlot.tsx
@@ -461,7 +461,7 @@ export function TimelinePlot({
     const firstRow = element.parentElement?.parentElement?.querySelector('[data-row-index="0"]');
     if (firstRow) setRestCenter((firstRow.getBoundingClientRect().top - rect.top) / 2);
   }, []);
-useEffect(() => measurePlot(), [measurePlot]);
+  useEffect(() => measurePlot(), [measurePlot]);
   useEffect(() => {
     const element = plotRef.current;
     if (!element) return;

--- a/src/app/staking/TimelinePlot.tsx
+++ b/src/app/staking/TimelinePlot.tsx
@@ -461,7 +461,7 @@ export function TimelinePlot({
     const firstRow = element.parentElement?.parentElement?.querySelector('[data-row-index="0"]');
     if (firstRow) setRestCenter((firstRow.getBoundingClientRect().top - rect.top) / 2);
   }, []);
-  useEffect(measurePlot);
+useEffect(() => measurePlot(), [measurePlot]);
   useEffect(() => {
     const element = plotRef.current;
     if (!element) return;

--- a/src/app/staking/__tests__/hoverCard.test.ts
+++ b/src/app/staking/__tests__/hoverCard.test.ts
@@ -1,0 +1,82 @@
+import { CARD_GAP, isInsideApproach, placeHoverCard, preferredSide } from '../hoverCard';
+
+const card = { width: 200, height: 120 };
+const view = { width: 1000, top: 0, bottom: 500 };
+const row = (top: number) => ({ rowTop: top, rowBottom: top + 28 });
+
+describe('placeHoverCard', () => {
+  it('centres the card on the pointer and rests it below the hovered row', () => {
+    const placement = placeHoverCard({ x: 400, ...row(100), side: 'below' }, card, view);
+    expect(placement).toEqual({ x: 300, y: 128 + CARD_GAP, side: 'below' });
+  });
+
+  it('keeps the card inside the plot horizontally', () => {
+    expect(placeHoverCard({ x: 20, ...row(100), side: 'below' }, card, view).x).toBe(0);
+    expect(placeHoverCard({ x: 990, ...row(100), side: 'below' }, card, view).x).toBe(800);
+  });
+
+  it('opens above the row when asked and there is room', () => {
+    const placement = placeHoverCard({ x: 400, ...row(300), side: 'above' }, card, view);
+    expect(placement).toEqual({ x: 300, y: 300 - CARD_GAP - card.height, side: 'above' });
+  });
+
+  it('may open past the top of the plot when the view allows it', () => {
+    const tall = { width: 1000, top: -300, bottom: 500 };
+    const placement = placeHoverCard({ x: 400, ...row(36), side: 'above' }, card, tall);
+    expect(placement).toEqual({ x: 300, y: 36 - CARD_GAP - card.height, side: 'above' });
+  });
+
+  it('falls back to the other side only when the preferred one cannot fit', () => {
+    expect(placeHoverCard({ x: 400, ...row(36), side: 'above' }, card, view)).toEqual({
+      x: 300,
+      y: 64 + CARD_GAP,
+      side: 'below',
+    });
+    expect(placeHoverCard({ x: 400, ...row(440), side: 'below' }, card, view)).toEqual({
+      x: 300,
+      y: 440 - CARD_GAP - card.height,
+      side: 'above',
+    });
+  });
+
+  it('clamps to the view when the card fits on neither side', () => {
+    const short = { width: 1000, top: 0, bottom: 100 };
+    expect(placeHoverCard({ x: 400, ...row(36), side: 'below' }, card, short).y).toBe(0);
+    expect(placeHoverCard({ x: 400, ...row(36), side: 'above' }, card, short).y).toBe(0);
+  });
+});
+
+describe('preferredSide', () => {
+  it('opens away from where the pointer is likely heading', () => {
+    expect(preferredSide(row(36), 444)).toBe('above');
+    expect(preferredSide(row(188), 444)).toBe('above');
+    expect(preferredSide(row(226), 444)).toBe('below');
+    expect(preferredSide(row(406), 444)).toBe('below');
+  });
+});
+
+describe('isInsideApproach', () => {
+  const anchor = { x: 400, ...row(300), side: 'below' as const };
+
+  it('reaches a card opened above or below the row', () => {
+    const above = { left: 300, right: 500, top: 130, bottom: 288 };
+    expect(isInsideApproach(anchor, above, { x: 380, y: 296 })).toBe(true);
+    expect(isInsideApproach(anchor, above, { x: 400, y: 340 })).toBe(false);
+    const below = { left: 300, right: 500, top: 340, bottom: 500 };
+    expect(isInsideApproach(anchor, below, { x: 430, y: 332 })).toBe(true);
+    expect(isInsideApproach(anchor, below, { x: 400, y: 290 })).toBe(false);
+  });
+
+  it('covers the wedge to a card beside the pointer, not the column below it', () => {
+    const beside = { left: 412, right: 612, top: 254, bottom: 374 };
+    expect(isInsideApproach(anchor, beside, { x: 406, y: 330 })).toBe(true);
+    expect(isInsideApproach(anchor, beside, { x: 400, y: 340 })).toBe(false);
+    expect(isInsideApproach(anchor, beside, { x: 420, y: 314 })).toBe(false);
+  });
+
+  it('is never inside when the card overlaps the pointer', () => {
+    expect(
+      isInsideApproach(anchor, { left: 300, right: 500, top: 254, bottom: 374 }, { x: 400, y: 314 })
+    ).toBe(false);
+  });
+});

--- a/src/app/staking/cycleColumns.tsx
+++ b/src/app/staking/cycleColumns.tsx
@@ -39,7 +39,6 @@ export const cycleColumns: ColumnDef<CycleRow>[] = [
     header: 'Cycle',
     accessorKey: 'cycleNumber',
     enableSorting: false,
-    meta: { isPinned: 'left' },
     size: 70,
     cell: info => (
       <Text textStyle="text-medium-sm">{(info.getValue() as number).toLocaleString()}</Text>

--- a/src/app/staking/hoverCard.ts
+++ b/src/app/staking/hoverCard.ts
@@ -1,0 +1,109 @@
+export const CARD_GAP = 12;
+
+export type HoverCardSide = 'below' | 'above';
+
+export interface HoverCardAnchor {
+  x: number;
+  rowTop: number;
+  rowBottom: number;
+  side: HoverCardSide;
+}
+
+export interface HoverCardSize {
+  width: number;
+  height: number;
+}
+
+export interface HoverCardView {
+  width: number;
+  top: number;
+  bottom: number;
+}
+
+export interface HoverCardPlacement {
+  x: number;
+  y: number;
+  side: HoverCardSide;
+}
+
+export interface HoverCardRect {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const cross = (p: Point, q: Point, r: Point) =>
+  (q.x - p.x) * (r.y - p.y) - (q.y - p.y) * (r.x - p.x);
+
+export function preferredSide(
+  band: { rowTop: number; rowBottom: number },
+  plotHeight: number
+): HoverCardSide {
+  return (band.rowTop + band.rowBottom) / 2 < plotHeight / 2 ? 'above' : 'below';
+}
+
+export function placeHoverCard(
+  anchor: HoverCardAnchor,
+  card: HoverCardSize,
+  view: HoverCardView
+): HoverCardPlacement {
+  const x = clamp(anchor.x - card.width / 2, 0, Math.max(view.width - card.width, 0));
+  const below = anchor.rowBottom + CARD_GAP;
+  const above = anchor.rowTop - CARD_GAP - card.height;
+  const fitsBelow = below + card.height <= view.bottom;
+  const fitsAbove = above >= view.top;
+  const side: HoverCardSide =
+    anchor.side === 'below'
+      ? fitsBelow || !fitsAbove
+        ? 'below'
+        : 'above'
+      : fitsAbove || !fitsBelow
+        ? 'above'
+        : 'below';
+  const y =
+    side === 'below'
+      ? Math.min(below, Math.max(view.bottom - card.height, view.top))
+      : Math.max(above, view.top);
+  return { x, y, side };
+}
+
+export function isInsideApproach(anchor: HoverCardAnchor, card: HoverCardRect, point: Point) {
+  const apex = { x: anchor.x, y: (anchor.rowTop + anchor.rowBottom) / 2 };
+  let edge: [Point, Point] | undefined;
+  if (card.bottom <= apex.y) {
+    edge = [
+      { x: card.left, y: card.bottom },
+      { x: card.right, y: card.bottom },
+    ];
+  } else if (card.top >= apex.y) {
+    edge = [
+      { x: card.left, y: card.top },
+      { x: card.right, y: card.top },
+    ];
+  } else if (card.left >= apex.x) {
+    edge = [
+      { x: card.left, y: card.top },
+      { x: card.left, y: card.bottom },
+    ];
+  } else if (card.right <= apex.x) {
+    edge = [
+      { x: card.right, y: card.top },
+      { x: card.right, y: card.bottom },
+    ];
+  }
+  if (!edge) return false;
+  const d1 = cross(apex, edge[0], point);
+  const d2 = cross(edge[0], edge[1], point);
+  const d3 = cross(edge[1], apex, point);
+  const hasNegative = d1 < 0 || d2 < 0 || d3 < 0;
+  const hasPositive = d1 > 0 || d2 > 0 || d3 > 0;
+  return !(hasNegative && hasPositive);
+}

--- a/src/ui/theme/theme.ts
+++ b/src/ui/theme/theme.ts
@@ -98,6 +98,12 @@ const themeConfig = {
     semanticTokens: {
       ...SEMANTIC_TOKENS,
     },
+    keyframes: {
+      'lifecycle-pulse': {
+        '0%': { transform: 'scale(1)', opacity: 0.45 },
+        '70%, 100%': { transform: 'scale(2.75)', opacity: 0 },
+      },
+    },
     textStyles: {
       ...TEXT_STYLES,
     },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Second design pass on the Bitcoin Staking page, following #2828. It addresses the recorded design review of the branch as of 4 Sep (Slack `#C0A8WSB8RQV`) and targets `feat/bitcoin-staking-page` so it lands inside #2827. Every item is a behaviour or tone fix; no data paths change.

### Timeline hover card

The review found the card easy to get stuck under: over a bar it stopped following, and because it sat 14px under the pointer with pointer events on, a quick move landed on the card, which then froze it, while a bond card would linger after moving back onto the grid. Movement on this chart is mostly vertical and diagonal along the staircase of bars, so any large card near the pointer while it moves is in the way.

- **Slim while moving, full when you stop.** While the pointer moves, only a one-line read-out follows it, 12px off the hovered row: cycle · height · date over the grid, `Bond 372 · enrolling · ~04 Sept → ~06 Sept` over a bar. Resting on a bar for 220ms (a slow drag along it counts as resting) expands it into the full card, anchored in place. Crossing the gap between two bars hands the label over directly instead of flashing the cycle read-out.
- **Opened away from where you are heading.** Rows in the upper half open the card above, rows in the lower half open it below, on the assumption that from the top you move down and from the bottom you move up. The card is portalled over the page and clamped to the viewport rather than the plot, so it can extend past the axis or the legend and the preferred side is available for every row; the old plot clipping made "above" impossible for the first four rows.
- **Interactive only when there is something to click.** Scheduled and enrolling bonds carry actions, so their expanded card takes pointer events and stays open while the pointer is on the bar, on the card, or inside the wedge between its resting point and the card's near edge (the menu "safe triangle"). A diagonal move onto a link holds; a straight move away releases at once. Other cards are pure tooltips.
- Placement, side choice and the wedge are pure functions in `hoverCard.ts` (unit-tested); `TimelinePlot` reads the hovered row through `data-row-index`.
- The divider above the card's actions is gone, and "Today" left the legend.

### Lifecycle

- Upcoming milestones step back in tone (`textSecondary`, still with the `~`) instead of taking the orange accent; reached milestones, including the current one, read in the primary colour without a `~` (the latest distribution used to render as projected).
- The current milestone's dot carries a soft halo that grows outward and fades (`lifecycle-pulse`, 2.4s, theme keyframe). It only runs while the bond is active and is off under `prefers-reduced-motion`.

### Tables

- The previous-cycles and bonds tables no longer pin their first column. The pin drew the shared table's 2px sticky edge, which reads as a stray divider between the first two columns; no other explorer table pins, and both still scroll inside `ScrollIndicator` on phones.

### Design decisions and trade-offs

- The 220ms rest before expanding follows the usual hover-intent guidance: the more a revealed panel covers, the surer you need to be that the pointer stopped on purpose. It is one constant (`REST_MS`) if it feels slow.
- Placing by plot half is a heuristic for direction; tracking actual pointer velocity was considered and left out because it makes the side flip mid-hover.
- Expanded cards of all bonds behave the same; only the ones with actions accept the pointer.
- The halo is limited to active bonds: a closed bond's last distribution is not "happening now".
- The review also noted the `BTC rewarded` caption wrapping when reward history is unavailable (private-1 only) and dismissed it; left as is.
- No workplan file: the branch's cleanup removed `docs/workplans/2822-bitcoin-staking-page.md`, so this description is the plan.

## Issue ticket number and link

Follow-up to #2828 inside #2827. Review thread: Slack `#C0A8WSB8RQV`, 4 Sep 2026.

## How to test

```
/staking?chain=testnet&api=https://api.private-1.hiro.so
/staking
```

1. Period overview: move across the grid and over bars — only a one-line read-out follows, 12px off your row. Rest on a bar for a beat and the card expands in place: above the row in the upper half of the chart, below it in the lower half. On a dashed (scheduled) or enrolling bar the card stays while you move into it to click a link, and lets go as soon as you move away in another direction. Sweep quickly down the staircase of bars: nothing large ever travels with the pointer.
2. Lifecycle: upcoming dates are grey with `~`; the current distribution's dot pulses (private-1 has one while a bond is active; mainnet Genesis has none until its first distribution).
3. STX-only staking → Previous cycles: no vertical edge after the Cycle column; at 375px the table still scrolls horizontally.

## Testing evidence

- `prettier --check` and `eslint` clean on every changed file.
- `jest`: 69 suites, 819 passed, 2 skipped, including 10 new `hoverCard` tests (placement, side rule, wedge).
- `tsc --noEmit`: no errors in `src/app/staking` or `src/ui/theme` (the 10 pre-existing lines elsewhere are unchanged).
- `next build`: passes.
- Headless Playwright against the dev server, 1440px and 375px: card placement measured relative to the hovered row in each state (slim label 12px off the row while moving; expanded above for upper rows, below for lower rows, past the plot's edges when needed), CTA link hit-testable while pinned, 0 frames with the card under the pointer moving down from an upper card or up from a lower one, only the slim label during a fast sweep down the staircase, a single content change when moving bar → bar, expanded card stays aligned through a page scroll, hover state survives the 10s data poll, `prefers-reduced-motion` disables the halo and the card transition, no horizontal page overflow at 375px.

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [x] I have added thorough tests where applicable.
- [x] I've added analytics and error logging where applicable. (No new data fetches; existing `logError` paths unchanged.)
