### PR TITLE
refactor: share UI components for bitcoin staking

### DIFF
--- a/src/app/_components/NetworkOverview/ChartTooltip.tsx
+++ b/src/app/_components/NetworkOverview/ChartTooltip.tsx
@@ -1,7 +1,7 @@
+import { ChartTooltipSurface } from '@/common/components/ChartTooltipSurface';
 import { truncateMiddle } from '@/common/utils/utils';
 import { useColorMode } from '@/components/ui/color-mode';
 import { Text } from '@/ui/Text';
-import { Stack } from '@chakra-ui/react';
 import { TooltipProps } from 'recharts';
 
 export function ChartTooltip({ active, payload, label }: TooltipProps<number, string>) {
@@ -28,19 +28,7 @@ export function ChartTooltip({ active, payload, label }: TooltipProps<number, st
     }
 
     return (
-      <Stack
-        bg={
-          colorMode === 'light'
-            ? 'var(--stacks-colors-alpha-black-alpha-700)'
-            : 'var(--stacks-colors-alpha-sand-alpha-400)'
-        }
-        px={2}
-        pt={1.5}
-        pb={2.5}
-        borderRadius="redesign.sm"
-        borderColor="borderPrimary"
-        gap={2.5}
-      >
+      <ChartTooltipSurface px={2} pt={1.5} pb={2.5} gap={2.5}>
         <Text
           textStyle={'text-medium-xs'}
           color={
@@ -71,7 +59,7 @@ export function ChartTooltip({ active, payload, label }: TooltipProps<number, st
         >
           {`In Bitcoin block ${truncateMiddle(dataPoint?.burnBlockHash, 4, 4)}`}
         </Text>
-      </Stack>
+      </ChartTooltipSurface>
     );
   }
   return null;

--- a/src/app/_components/StackingSection/StackingSection.tsx
+++ b/src/app/_components/StackingSection/StackingSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useHomePageData } from '@/app/context';
+import { ProgressBar } from '@/common/components/ProgressBar';
 import { useGlobalContext } from '@/common/context/useGlobalContext';
 import { buildUrl } from '@/common/utils/buildUrl';
 import { formatDateShort } from '@/common/utils/date-utils';
@@ -12,58 +13,9 @@ import BitcoinCircleIcon from '@/ui/icons/BitcoinCircleIcon';
 import ProgressDot from '@/ui/icons/ProgressDot';
 import StacksIconThin from '@/ui/icons/StacksIconThin';
 import StxSquareIcon from '@/ui/icons/StxSquareIcon';
-import { Box, BoxProps, Flex, HStack, Icon, Stack } from '@chakra-ui/react';
+import { Flex, HStack, Icon, Stack } from '@chakra-ui/react';
 
 import { SSRDisabledMessage } from '../SSRDisabledMessage';
-
-function ProgressKnob({ diameter, ...boxProps }: { diameter: number } & BoxProps) {
-  return (
-    <Box
-      bg={{ base: 'white', _dark: 'neutral.sand-900' }}
-      h={diameter}
-      w={diameter}
-      borderRadius={'redesign.2xl'}
-      position="absolute"
-      top="50%"
-      bottom="50%"
-      m="auto"
-      {...boxProps}
-    />
-  );
-}
-
-function ProgressBar({ percentage }: { percentage?: number }) {
-  const PROGRESS_KNOB_DIAMETER = 1;
-  return (
-    <Stack
-      bg={{
-        base: 'neutral.sand-200',
-        _dark: 'neutral.sand-700',
-      }}
-      h={2}
-      borderRadius={'redesign.xl'}
-      w="100%"
-      position="relative"
-    >
-      <Stack
-        bg={'accent.stacks-500'}
-        h={2}
-        borderRadius={'redesign.2xl'}
-        w={`${percentage}%`}
-        position="absolute"
-        boxShadow={'0px 2px 10px 0px rgba(255, 85, 18, 0.50)'}
-      />
-      <ProgressKnob
-        diameter={PROGRESS_KNOB_DIAMETER}
-        left={`calc(var(--stacks-spacing-${PROGRESS_KNOB_DIAMETER}) / 2)`}
-      />
-      <ProgressKnob
-        diameter={PROGRESS_KNOB_DIAMETER}
-        right={`calc(var(--stacks-spacing-${PROGRESS_KNOB_DIAMETER}) / 2)`}
-      />
-    </Stack>
-  );
-}
 
 function CycleHeader() {
   const homePageData = useHomePageData();

--- a/src/app/transactions/Overview.tsx
+++ b/src/app/transactions/Overview.tsx
@@ -1,7 +1,7 @@
+import { OverviewCard } from '@/common/components/OverviewCard';
 import { Text } from '@/ui/Text';
 import StxThinIcon from '@/ui/icons/StacksThinIcon';
-import { Flex, Grid, Icon, Stack, StackProps } from '@chakra-ui/react';
-import { ReactNode } from 'react';
+import { Flex, Grid, Icon, Stack } from '@chakra-ui/react';
 
 export const Overview = () => {
   return (
@@ -78,51 +78,3 @@ const overviewCards = [
     stat: 643,
   },
 ];
-
-export const OverviewCard = ({
-  title,
-  stat,
-  subStat,
-  ...rest
-}: { title: string; stat: ReactNode; subStat?: string } & StackProps) => {
-  return (
-    <Stack
-      aria-label={title}
-      py={3}
-      px={4}
-      bg="surfacePrimary"
-      borderRadius="redesign.md"
-      {...rest}
-      css={{
-        '&:first-of-type': {
-          bg: 'linear-gradient(138deg, var(--stacks-colors-surface-primary) 73.53%, #FF5512 161.25%)',
-        },
-      }}
-    >
-      <Text textStyle="text-medium-sm" color={'textSecondary'} whiteSpace="nowrap">
-        {title}
-      </Text>
-      <Flex gap={1.5} alignItems="baseline">
-        {typeof stat === 'number' || typeof stat === 'string' ? (
-          <Text
-            fontWeight="medium"
-            textStyle="heading-sm"
-            color={'textPrimary'}
-            whiteSpace="nowrap"
-          >
-            {stat}
-          </Text>
-        ) : (
-          stat
-        )}
-        {typeof subStat === 'string' || typeof subStat === 'number' ? (
-          <Text textStyle="text-regular-sm" color={'textSecondary'} whiteSpace="nowrap">
-            {subStat}
-          </Text>
-        ) : (
-          subStat
-        )}
-      </Flex>
-    </Stack>
-  );
-};

--- a/src/common/components/ChartTooltipSurface.tsx
+++ b/src/common/components/ChartTooltipSurface.tsx
@@ -1,0 +1,22 @@
+import { useColorMode } from '@/components/ui/color-mode';
+import { Stack } from '@chakra-ui/react';
+import type { StackProps } from '@chakra-ui/react';
+
+export function ChartTooltipSurface({ children, ...props }: StackProps) {
+  const { colorMode } = useColorMode();
+
+  return (
+    <Stack
+      bg={
+        colorMode === 'light'
+          ? 'var(--stacks-colors-alpha-black-alpha-700)'
+          : 'var(--stacks-colors-alpha-sand-alpha-400)'
+      }
+      backdropFilter="blur(8px)"
+      borderRadius="redesign.sm"
+      {...props}
+    >
+      {children}
+    </Stack>
+  );
+}

--- a/src/common/components/ChartTooltipSurface.tsx
+++ b/src/common/components/ChartTooltipSurface.tsx
@@ -1,17 +1,10 @@
-import { useColorMode } from '@/components/ui/color-mode';
 import { Stack } from '@chakra-ui/react';
 import type { StackProps } from '@chakra-ui/react';
 
 export function ChartTooltipSurface({ children, ...props }: StackProps) {
-  const { colorMode } = useColorMode();
-
   return (
     <Stack
-      bg={
-        colorMode === 'light'
-          ? 'var(--stacks-colors-alpha-black-alpha-700)'
-          : 'var(--stacks-colors-alpha-sand-alpha-400)'
-      }
+      bg={{ base: 'alpha.black-alpha-700', _dark: 'alpha.sand-alpha-400' }}
       backdropFilter="blur(8px)"
       borderRadius="redesign.sm"
       {...props}

--- a/src/common/components/OverviewCard.tsx
+++ b/src/common/components/OverviewCard.tsx
@@ -1,0 +1,54 @@
+import { Text } from '@/ui/Text';
+import { Flex, Stack } from '@chakra-ui/react';
+import type { StackProps } from '@chakra-ui/react';
+import type { ReactNode } from 'react';
+
+interface OverviewCardProps extends Omit<StackProps, 'title'> {
+  title: ReactNode;
+  stat: ReactNode;
+  subStat?: ReactNode;
+  caption?: ReactNode;
+}
+
+export function OverviewCard({ title, stat, subStat, caption, ...rest }: OverviewCardProps) {
+  return (
+    <Stack
+      aria-label={typeof title === 'string' ? title : undefined}
+      py={3}
+      px={4}
+      bg="surfacePrimary"
+      borderRadius="redesign.md"
+      {...rest}
+      css={{
+        '&:first-of-type': {
+          bg: 'linear-gradient(138deg, var(--stacks-colors-surface-primary) 73.53%, #FF5512 161.25%)',
+        },
+      }}
+    >
+      <Text textStyle="text-medium-sm" color="textSecondary" whiteSpace="nowrap">
+        {title}
+      </Text>
+      <Flex gap={1.5} alignItems="baseline">
+        {typeof stat === 'number' || typeof stat === 'string' ? (
+          <Text fontWeight="medium" textStyle="heading-sm" color="textPrimary" whiteSpace="nowrap">
+            {stat}
+          </Text>
+        ) : (
+          stat
+        )}
+        {typeof subStat === 'string' || typeof subStat === 'number' ? (
+          <Text textStyle="text-regular-sm" color="textSecondary" whiteSpace="nowrap">
+            {subStat}
+          </Text>
+        ) : (
+          subStat
+        )}
+      </Flex>
+      {caption && (
+        <Text textStyle="text-regular-xs" color="textSecondary">
+          {caption}
+        </Text>
+      )}
+    </Stack>
+  );
+}

--- a/src/common/components/ProgressBar.test.tsx
+++ b/src/common/components/ProgressBar.test.tsx
@@ -1,0 +1,19 @@
+import { renderWithChakraProviders } from '@/common/utils/test-utils/render-utils';
+import { screen } from '@testing-library/react';
+
+import { ProgressBar } from './ProgressBar';
+
+test.each([
+  [25, '25'],
+  [-10, '0'],
+  [110, '100'],
+  [undefined, '0'],
+  [Number.NaN, null],
+  [Number.POSITIVE_INFINITY, null],
+])('exposes an accessible progress value for %s', (percentage, expected) => {
+  renderWithChakraProviders(<ProgressBar percentage={percentage} />);
+  const progress = screen.getByRole('progressbar', { name: 'Stacking cycle progress' });
+  expect(progress).toHaveAttribute('aria-valuemin', '0');
+  expect(progress).toHaveAttribute('aria-valuemax', '100');
+  expect(progress.getAttribute('aria-valuenow')).toBe(expected);
+});

--- a/src/common/components/ProgressBar.tsx
+++ b/src/common/components/ProgressBar.tsx
@@ -1,0 +1,54 @@
+import { Box, Stack } from '@chakra-ui/react';
+import type { BoxProps } from '@chakra-ui/react';
+
+const PROGRESS_KNOB_DIAMETER = 1;
+
+function ProgressKnob({ diameter, ...boxProps }: { diameter: number } & BoxProps) {
+  return (
+    <Box
+      bg={{ base: 'white', _dark: 'neutral.sand-900' }}
+      h={diameter}
+      w={diameter}
+      borderRadius={'redesign.2xl'}
+      position="absolute"
+      top="50%"
+      bottom="50%"
+      m="auto"
+      {...boxProps}
+    />
+  );
+}
+
+export function ProgressBar({ percentage = 0 }: { percentage?: number }) {
+  const progress = Math.min(Math.max(percentage, 0), 100);
+
+  return (
+    <Stack
+      bg={{
+        base: 'neutral.sand-200',
+        _dark: 'neutral.sand-700',
+      }}
+      h={2}
+      borderRadius={'redesign.xl'}
+      w="100%"
+      position="relative"
+    >
+      <Stack
+        bg={'accent.stacks-500'}
+        h={2}
+        borderRadius={'redesign.2xl'}
+        w={`${progress}%`}
+        position="absolute"
+        boxShadow={'0px 2px 10px 0px rgba(255, 85, 18, 0.50)'}
+      />
+      <ProgressKnob
+        diameter={PROGRESS_KNOB_DIAMETER}
+        left={`calc(var(--stacks-spacing-${PROGRESS_KNOB_DIAMETER}) / 2)`}
+      />
+      <ProgressKnob
+        diameter={PROGRESS_KNOB_DIAMETER}
+        right={`calc(var(--stacks-spacing-${PROGRESS_KNOB_DIAMETER}) / 2)`}
+      />
+    </Stack>
+  );
+}

--- a/src/common/components/ProgressBar.tsx
+++ b/src/common/components/ProgressBar.tsx
@@ -24,6 +24,11 @@ export function ProgressBar({ percentage = 0 }: { percentage?: number }) {
   const progress = Math.min(Math.max(safePercentage, 0), 100);
   return (
     <Stack
+      role="progressbar"
+      aria-label="Stacking cycle progress"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Number.isFinite(percentage) ? progress : undefined}
       bg={{
         base: 'neutral.sand-200',
         _dark: 'neutral.sand-700',
@@ -39,7 +44,7 @@ export function ProgressBar({ percentage = 0 }: { percentage?: number }) {
         borderRadius={'redesign.2xl'}
         w={`${progress}%`}
         position="absolute"
-        boxShadow={'0px 2px 10px 0px rgba(255, 85, 18, 0.50)'}
+        boxShadow="brandGlow"
       />
       <ProgressKnob
         diameter={PROGRESS_KNOB_DIAMETER}

--- a/src/common/components/ProgressBar.tsx
+++ b/src/common/components/ProgressBar.tsx
@@ -20,8 +20,8 @@ function ProgressKnob({ diameter, ...boxProps }: { diameter: number } & BoxProps
 }
 
 export function ProgressBar({ percentage = 0 }: { percentage?: number }) {
-  const progress = Math.min(Math.max(percentage, 0), 100);
-
+  const safePercentage = Number.isFinite(percentage) ? percentage : 0;
+  const progress = Math.min(Math.max(safePercentage, 0), 100);
   return (
     <Stack
       bg={{

--- a/src/common/components/table/Table.test.tsx
+++ b/src/common/components/table/Table.test.tsx
@@ -1,9 +1,17 @@
 import { renderWithChakraProviders } from '@/common/utils/test-utils/render-utils';
 import { Column, ColumnDef } from '@tanstack/react-table';
-import { fireEvent, screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { Table, getColumnPinningState, getCommonPinningStyles } from './Table';
+
+beforeAll(() => {
+  global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+  }));
+});
 
 test('header help is keyboard-focusable and activation does not sort the column', async () => {
   const user = userEvent.setup();
@@ -18,9 +26,12 @@ test('header help is keyboard-focusable and activation does not sort the column'
   const trigger = screen.getByRole('button', { name: 'About Amount' });
   await user.tab();
   expect(trigger).toHaveFocus();
+  expect(await screen.findByRole('tooltip')).toHaveTextContent('Amount in BTC.');
   await user.keyboard('{Enter}');
   expect(onSort).not.toHaveBeenCalled();
-  fireEvent.click(screen.getByText('Amount', { exact: true }));
+  await user.keyboard('{Escape}');
+  await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument());
+  await user.click(screen.getByText('Amount', { exact: true }));
   expect(onSort).toHaveBeenCalledWith('amount', 'desc');
 });
 

--- a/src/common/components/table/Table.test.tsx
+++ b/src/common/components/table/Table.test.tsx
@@ -19,20 +19,25 @@ afterAll(() => {
   globalThis.ResizeObserver = originalResizeObserver;
 });
 
-test('header help is keyboard-focusable and activation does not sort the column', async () => {
+test.each([
+  { header: 'Amount', name: 'About Amount' },
+  { header: () => 'Amount', name: 'About amount' },
+])('header help "$name" opens outside the table without sorting', async ({ header, name }) => {
   const user = userEvent.setup();
   const onSort = jest.fn(async () => [{ amount: 1 }]);
-  renderWithChakraProviders(
+  const { container } = renderWithChakraProviders(
     <Table
       data={[{ amount: 1 }]}
-      columns={[{ accessorKey: 'amount', header: 'Amount', meta: { tooltip: 'Amount in BTC.' } }]}
+      columns={[{ accessorKey: 'amount', header, meta: { tooltip: 'Amount in BTC.' } }]}
       onSort={onSort}
     />
   );
-  const trigger = screen.getByRole('button', { name: 'About Amount' });
+  const trigger = screen.getByRole('button', { name });
   await user.tab();
   expect(trigger).toHaveFocus();
-  expect(await screen.findByRole('tooltip')).toHaveTextContent('Amount in BTC.');
+  const tooltip = await screen.findByRole('tooltip');
+  expect(tooltip).toHaveTextContent('Amount in BTC.');
+  expect(container).not.toContainElement(tooltip);
   await user.keyboard('{Enter}');
   expect(onSort).not.toHaveBeenCalled();
   await user.keyboard('{Escape}');

--- a/src/common/components/table/Table.test.tsx
+++ b/src/common/components/table/Table.test.tsx
@@ -1,6 +1,28 @@
+import { renderWithChakraProviders } from '@/common/utils/test-utils/render-utils';
 import { Column, ColumnDef } from '@tanstack/react-table';
+import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-import { getColumnPinningState, getCommonPinningStyles } from './Table';
+import { Table, getColumnPinningState, getCommonPinningStyles } from './Table';
+
+test('header help is keyboard-focusable and activation does not sort the column', async () => {
+  const user = userEvent.setup();
+  const onSort = jest.fn(async () => [{ amount: 1 }]);
+  renderWithChakraProviders(
+    <Table
+      data={[{ amount: 1 }]}
+      columns={[{ accessorKey: 'amount', header: 'Amount', meta: { tooltip: 'Amount in BTC.' } }]}
+      onSort={onSort}
+    />
+  );
+  const trigger = screen.getByRole('button', { name: 'About Amount' });
+  await user.tab();
+  expect(trigger).toHaveFocus();
+  await user.keyboard('{Enter}');
+  expect(onSort).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByText('Amount', { exact: true }));
+  expect(onSort).toHaveBeenCalledWith('amount', 'desc');
+});
 
 describe('getCommonPinningStyles', () => {
   const createMockColumn = (isPinned: 'left' | 'right' | false, isLastColumn: boolean = false) => {
@@ -23,7 +45,7 @@ describe('getCommonPinningStyles', () => {
     const styles = getCommonPinningStyles(column);
 
     expect(styles).toEqual({
-      bg: 'surface',
+      bg: 'surfaceTertiary',
       left: '100px',
       right: undefined,
       opacity: 1,
@@ -37,7 +59,7 @@ describe('getCommonPinningStyles', () => {
     const styles = getCommonPinningStyles(column);
 
     expect(styles).toEqual({
-      bg: 'surface',
+      bg: 'surfaceTertiary',
       left: undefined,
       right: '200px',
       opacity: 1,
@@ -51,7 +73,7 @@ describe('getCommonPinningStyles', () => {
     const styles = getCommonPinningStyles(column);
 
     expect(styles).toEqual({
-      bg: 'surface',
+      bg: 'surfaceTertiary',
       left: '100px',
       right: undefined,
       opacity: 1,

--- a/src/common/components/table/Table.test.tsx
+++ b/src/common/components/table/Table.test.tsx
@@ -5,12 +5,18 @@ import userEvent from '@testing-library/user-event';
 
 import { Table, getColumnPinningState, getCommonPinningStyles } from './Table';
 
+const originalResizeObserver = globalThis.ResizeObserver;
+
 beforeAll(() => {
-  global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  (globalThis as any).ResizeObserver = jest.fn().mockImplementation(() => ({
     observe: jest.fn(),
     unobserve: jest.fn(),
     disconnect: jest.fn(),
   }));
+});
+
+afterAll(() => {
+  globalThis.ResizeObserver = originalResizeObserver;
 });
 
 test('header help is keyboard-focusable and activation does not sort the column', async () => {

--- a/src/common/components/table/Table.tsx
+++ b/src/common/components/table/Table.tsx
@@ -422,6 +422,7 @@ export function Table<T>({
                     )}
                     {header.column.columnDef.meta?.tooltip && (
                       <Tooltip
+                        portalled
                         content={header.column.columnDef.meta.tooltip}
                         contentProps={{ maxW: '20rem', whiteSpace: 'normal', textAlign: 'left' }}
                       >
@@ -430,12 +431,17 @@ export function Table<T>({
                           aria-label={
                             typeof header.column.columnDef.header === 'string'
                               ? `About ${header.column.columnDef.header}`
-                              : 'About this column'
+                              : `About ${header.column.id}`
                           }
                           display="inline-flex"
+                          alignItems="center"
+                          justifyContent="center"
+                          minW={6}
+                          minH={6}
                           flexShrink={0}
                           cursor="help"
                           focusVisibleRing="outside"
+                          focusRingColor="brand"
                           onClick={event => event.stopPropagation()}
                         >
                           <Icon h={3.5} w={3.5} color="iconSecondary">

--- a/src/common/components/table/Table.tsx
+++ b/src/common/components/table/Table.tsx
@@ -8,6 +8,7 @@ import {
   Icon,
   Spinner,
   Stack,
+  chakra,
 } from '@chakra-ui/react';
 import { ArrowDown, ArrowUp, ArrowsDownUp, Info, WarningOctagon } from '@phosphor-icons/react';
 import {
@@ -56,7 +57,7 @@ export const getCommonPinningStyles = <T,>(column: Column<T>) => {
   }
 
   return {
-    bg: 'surface',
+    bg: 'surfaceTertiary',
     left: isPinned === 'left' ? `${column.getStart('left')}px` : undefined,
     right: isPinned === 'right' ? `${column.getAfter('right')}px` : undefined,
     opacity: 1,
@@ -420,10 +421,27 @@ export function Table<T>({
                       flexRender(header.column.columnDef.header, header.getContext())
                     )}
                     {header.column.columnDef.meta?.tooltip && (
-                      <Tooltip content={header.column.columnDef.meta.tooltip}>
-                        <Icon h={4} w={4} color="iconSecondary">
-                          <Info />
-                        </Icon>
+                      <Tooltip
+                        content={header.column.columnDef.meta.tooltip}
+                        contentProps={{ maxW: '20rem', whiteSpace: 'normal', textAlign: 'left' }}
+                      >
+                        <chakra.button
+                          type="button"
+                          aria-label={
+                            typeof header.column.columnDef.header === 'string'
+                              ? `About ${header.column.columnDef.header}`
+                              : 'About this column'
+                          }
+                          display="inline-flex"
+                          flexShrink={0}
+                          cursor="help"
+                          focusVisibleRing="outside"
+                          onClick={event => event.stopPropagation()}
+                        >
+                          <Icon h={3.5} w={3.5} color="iconSecondary">
+                            <Info />
+                          </Icon>
+                        </chakra.button>
                       </Tooltip>
                     )}
                     <SortIcon

--- a/src/ui/theme/shadows.ts
+++ b/src/ui/theme/shadows.ts
@@ -1,4 +1,7 @@
 export const SHADOWS = {
+  brandGlow: {
+    value: '0px 2px 10px 0px {colors.alpha.stacks-500-alpha-50}',
+  },
   elevation1: {
     value: {
       base: '0 2px 6px rgba(183, 180, 176, 0.2)',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Extracts reusable UI components and updates shared table help before the Bitcoin staking feature
is introduced. This is the first of five focused PRs targeting `feat/bitcoin-staking`.

- Move `OverviewCard`, `ProgressBar`, and `ChartTooltipSurface` into shared components and update their existing callers.
- Background changes to chart-tooltip blur and pinned-column background. Header tooltips are left-aligned and keyboard-accessible, with visible focus.

## Issue ticket number and link

Split from #2827. Integration target: `feat/bitcoin-staking`.
